### PR TITLE
doc(get-started): modify class name in child router sample from Welcome to ChildRouter

### DIFF
--- a/English/get-started.md
+++ b/English/get-started.md
@@ -473,7 +473,7 @@ Nothing new there. The interesting part is what's inside _child-router.js_...
 ```javascript
 import {Router} from 'aurelia-router';
 
-export class Welcome{
+export class ChildRouter{
   static inject() { return [Router]; }
   constructor(router){
     this.heading = 'Child Router';

--- a/Spanish/get-started.md
+++ b/Spanish/get-started.md
@@ -473,7 +473,7 @@ Nada nuevo en esto. La parte interesante es lo que está dentro de _child-router
 ```javascript
 import {Router} from 'aurelia-router';
 
-export class Welcome{
+export class ChildRouter{
   static inject() { return [Router]; }
   constructor(router){
     this.heading = 'Child Router';


### PR DESCRIPTION
Just a small fix in Getting Started document... and to get familiar with GitHub pull requests :)