### PR TITLE
Improved the readability of HTML code blocks

### DIFF
--- a/Chinese/get_started.md
+++ b/Chinese/get_started.md
@@ -49,7 +49,7 @@
 如果你跟着我们走到这里了，那你现在已经有所有需要的库了，也已经有创建 Aurelia 应用的组建配置文件和工具了。下一步要做的事情是在项目的根目录下创建 _index.html_ 文件。新建这个文件，并替换为下面的内容。
 
 ### index.html
-```markup
+```html
 <!doctype html>
 <html>
   <head>
@@ -118,7 +118,7 @@ export class Welcome{
 好了，现在已经有一个具有一些基本的数据和行为的 _view-model_ 了，下面来看看它的同伴—— _view_。
 
 ### app.html
-```markup
+```html
 <template>
   <section>
     <h2>${heading}</h2>
@@ -203,7 +203,7 @@ Aurelia 是按需创建 UI 组件来渲染页面的。这是通过使用一个�
 
 ### app.html
 
-```markup
+```html
 <template>
   <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="navbar-header">
@@ -317,7 +317,7 @@ jspm install aurelia-http-client
 
 ### flickr.html
 
-```markup
+```html
 <template>
     <section>
         <h2>${heading}</h2>
@@ -349,7 +349,7 @@ jspm install aurelia-http-client
 
 ### app.html
 
-```markup
+```html
 <template>
   <import from='./nav-bar'></import>
 
@@ -378,7 +378,7 @@ export class NavBar {
 
 ### nav-bar.html
 
-```markup
+```html
 <template>
   <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="navbar-header">
@@ -416,7 +416,7 @@ export class NavBar {
 
 ### app.html
 
-```markup
+```html
 <template>
   <import from='./nav-bar'></import>
 

--- a/English/docs.md
+++ b/English/docs.md
@@ -157,7 +157,7 @@ Now, each time the DI container is asked for an instance of `CustomerDetail` the
 
 Aurelia's templating engine is responsible for loading your views and their imported resources, compiling your HTML for optimal performance and rendering your UI to the screen. To create a view, all you need to do is author an HTML file with an `HTMLTemplate` inside. Here's a simple view:
 
-```markup
+```html
 <template>
     <div>Hello World!</div>
 </template>
@@ -165,7 +165,7 @@ Aurelia's templating engine is responsible for loading your views and their impo
 
 Everything inside the `template` tag will be managed by Aurelia. However, since Aurelia uses HTMLImport technology to load views, you can also include links, and they will be properly loaded, including relative resource resolution semantics. In other words, you can do this:
 
-```markup
+```html
 <link rel="stylesheet" type="text/css" href="./hello.css">
 
 <template>
@@ -177,7 +177,7 @@ This enables you to dynamically load per-view style sheets and even Web Componen
 
 Any time you want to import an Aurelia-specific resource, such as an Aurelia _Custom Element_, _Attached Behavior_, _Template Controller_ or _Value Converter_, you should use an `import` element inside your view instead. Here's an example:
 
-```markup
+```html
 <template>
   <import from='./nav-bar'></import>
 
@@ -218,7 +218,7 @@ _What does this mean though?_
 
 One-way binding means that changes flow from your JavaScript view-models into the view, not from the view into the view-model. Two-way binding means that changes flow in both directions. `.bind` attempts to use a sensible default by assuming that if you are binding to a form element's value property then you probably wish the changes made in the form to flow into your view-model. For everything else it uses one-way binding, especially since, in many cases, two-way binding to non-form elements would be nonsensical. Here's a small binding example using `.bind`:
 
-```markup
+```html
 <input type="text" value.bind="firstName">
 <a href.bind="url">Aurelia</a>
 ```
@@ -227,7 +227,7 @@ In the above example, the `input` will have its `value` bound to the `firstName`
 
 You can always be explicit and use `.one-way` or `.two-way` in place of `.bind`though. A common case where this is required is with Web Components that function as input-type controls. So, you can imagine doing something like this:
 
-```markup
+```html
 <markdown-editor value.two-way="markdown"></markdown-editor>
 ```
 
@@ -237,13 +237,13 @@ In order to optimize performance and minimize CPU and memory usage, you can alte
 
 Binding commands don't only connect properties and attributes, but can be used to trigger behavior. For example, if you want to invoke a method on the view-model when a button is clicked, you would use the `trigger` command like this:
 
-```markup
+```html
 <button click.trigger="sayHello()">Say Hello</button>
 ```
 
 When the button is clicked, the `sayHello` method on the view-model will be invoked. That said, adding event handlers to every single element like this isn't very efficient, so often times you will want to use event delegation. To do that, use the `.delegate` command. Here's the same example but with event delegation instead:
 
-```markup
+```html
 <button click.delegate="sayHello()">Say Hello</button>
 ```
 
@@ -251,7 +251,7 @@ When the button is clicked, the `sayHello` method on the view-model will be invo
 
 All of this works against DOM events in some way or another. Occasionally you may have a custom Aurelia behavior that wants a reference to your function directly so that it can invoke it manually at a later time. To pass a function reference, use the `.call` binding (since the behavior will _call_ it later):
 
-```markup
+```html
 <div touch.call="sayHello()">Say Hello</button>
 ```
 
@@ -259,7 +259,7 @@ Now the attached behavior will get a function that it can call to invoke your `s
 
 The `$event` property can be passed as an argument to a delegated function call if you need to access the event object.
 
-```markup
+```html
 <button click.delegate="sayHello($event)">Say Hello</button>
 ```
 
@@ -267,13 +267,13 @@ The `$event` property can be passed as an argument to a delegated function call 
 
 Sometimes you need to bind properties directly into the content of the document or interleave them within an attribute value. For this, you can use the string interpolation syntax `${expression}`. String interpolation is a one-way binding, the output of which is converted to a string. Here's an example:
 
-```markup
+```html
 <span>${fullName}</span>
 ```
 
 The `fullName` property will be interpolated directly into the span's content. You can also use this to handle css class bindings like so:
 
-```markup
+```html
 <div class="dot ${color} ${isHappy ? 'green' : 'red'}"></div>
 ```
 
@@ -285,13 +285,13 @@ In this snippet "dot" is a statically present class and "green" is present only 
 
 In addition to commands and interpolation, the binding language recognizes the use of a special attribute: `ref`. By using `ref` you can create a local name for an element which can then be referenced in another binding expression. It will also be set as a property on the view-model, so you can access it through code. Here's a neat example of using `ref`:
 
-```markup
+```html
 <input type="text" ref="name"> ${name.value}
 ```
 
 You can also use the special `.view-model` binding in conjuction with `ref` to get the view-model instance that backs an Aurelia Custom Element. By using this technique, you can connect different components to each other like so:
 
-```markup
+```html
 <i-produce-a-value ref.view-model="producer"></i-produce-a-value>
 <i-consume-a-value input.bind="producer.output"></i-consume-a-value>
 ```
@@ -310,7 +310,7 @@ Naturally, all of this works seemlessly with databinding. Let's look at the beha
 
 The `show` Attached Behavior allows you to conditionally display an HTML element. If the value of show is `true` the element will be displayed, otherwise it will be hidden. This behavior does not add/remove the element from the DOM, but only changes its visibility. Here's an example:
 
-```markup
+```html
 <div show.bind="isSaving" class="spinner"></div>
 ```
 
@@ -320,7 +320,7 @@ When the `isSaving` property is true, the `div` will be visible, otherwise it wi
 
 The `if` Template Controller allows you to conditionally add/remove an HTML element. If the value is true, the element will also be present in the DOM, otherwise it will not.
 
-```markup
+```html
 <div if.bind="isSaving" class="spinner"></div>
 ```
 
@@ -328,7 +328,7 @@ This example looks similar to that of `show` above. The difference is that if th
 
 If you need to conditionally add/remove a group of elements and you cannot place the `if` behavior on a parent element, then you can wrap those elements in a template tag which has the `if` behavior. Here's what that would look like:
 
-```markup
+```html
 <template if.bind="hasErrors">
     <i class="icon error"></i>
     ${errorMessage}
@@ -339,7 +339,7 @@ If you need to conditionally add/remove a group of elements and you cannot place
 
 The `repeat` Template Controller allows you to render a template multiple times, once for each item in an array. Here's an example that renders out a list of customer names:
 
-```markup
+```html
 <ul>
     <li repeat.for="customer of customers">${customer.fullName}</li>
 </ul>
@@ -353,7 +353,7 @@ An important note about the repeat behavior is that it works in conjuction with 
 
 The `compose` Custom Element enables you to dynamically render UI into the DOM. Imagine you have a heterogeneous array of items, but each has a type property which tells you what it is. You can then do something like this:
 
-```markup
+```html
 <template repeat.for="item of items">
     <compose
       model.bind="item"
@@ -372,7 +372,7 @@ What if you want to determine the view dynamically based on data though? or runt
 
 HTMLSelectElement is an interesting beast. Usually, you can databind these by combining a `repeat` for the options with a binding on the value, like this:
 
-```markup
+```html
 <select value.bind="favoriteNumber">
     <option>Select A Number</option>
     <option repeat.for="number of numbers" value.bind="number">${number}</option>
@@ -381,7 +381,7 @@ HTMLSelectElement is an interesting beast. Usually, you can databind these by co
 
 But sometimes you want to work with selecting object instances rather than primitives. For that you can use the `selected-item` attached behavior. Here's how you would configure that for a theoretical list of employees:
 
-```markup
+```html
 <select selected-item.bind="employeeOfTheMonth">
   <option>Select An Employee</option>
   <option repeat.for="employee of employees" value.bind="employee.id" model.bind="employee">${employee.fullName}</option>
@@ -396,7 +396,7 @@ First, we specify the `.bind` binding command on `selected-item`. We then use a 
 
 This is not an Attached Behavior that you will use directly. Rather, it works in conjunction with a custom binding command to dynamically enable the use of jQuery plugins and similar APIs declaratively in HTML. Let's look at an example in order to help clarify the idea:
 
-```markup
+```html
 <div jquery.modal="show: true; keyboard.bind: allowKeyboard">...</div>
 ```
 
@@ -455,7 +455,7 @@ So, what options to you have for the route pattern?
 
 All routes with a truthy `nav` property are assembled into a `navigation` array. This makes it really easy to use databinding to generate a menu structure. Another important property for binding is the `isNavigating` property. Here's some simple markup that shows what you might pair with the view-model shown above:
 
-```markup
+```html
 <template>
   <ul>
     <li class="loader" if.bind="router.isNavigating">
@@ -695,7 +695,7 @@ Attached Behaviors tend to represent cross-cutting concerns. For example you mig
 
 Let's look at one of Aurelia's own Attached Behavior implementations: `show`. Here's how it is used:
 
-```markup
+```html
 <div show.bind="isSaving" class="spinner"></div>
 ```
 
@@ -786,7 +786,7 @@ export class Show {
 
 This creates an Attached Behavior named `my-behavior` with two properties `foo` and `bar`. Each of these properties are available directly on the class, however they are configured in HTML a bit different. Here's how that would be done:
 
-```markup
+```html
 <div my-behavior="foo: some literal value; bar.bind: some.expression"></div>
 ```
 
@@ -800,7 +800,7 @@ Custom Elements add new tags to your HTML markup. Each Custom Element can have i
 
 Why don't we create a simple custom element so that we can see how that works? We'll make an element that says hello to someone, called `say-hello`. Here's how we want to be able to use it when we're done:
 
-```markup
+```html
 <template>
     <import from="./say-hello"></import>
 
@@ -848,7 +848,7 @@ export class SayHelloCustomElement {
 Be default, Custom Elements have a view. Here's the view for ours:
 
 #### say-hello.html
-```markup
+```html
 <template>
     <button click.delegate="speak()">Say Hello To ${to}</button>
 </template>

--- a/English/get-started.md
+++ b/English/get-started.md
@@ -50,7 +50,7 @@ Everything we've done so far is standard Node.js build and package management pr
 If you've followed along this far, you now have all the libraries, build configuration and tools you need to create amazing JavaScript apps with Aurelia. The next thing we need to do is create our _index.html_ file in the root of our project folder. Create that now and use the markup below.
 
 ### index.html
-```markup
+```html
 <!doctype html>
 <html>
   <head>
@@ -119,7 +119,7 @@ Yes. Yes it is. In fact it's ECMAScript 6 (ES6), the next version of JavaScript 
 Ok. Now that we have a _view-model_ with some basic data and behavior, let's have a look at its partner in crime...the _view_.
 
 ### app.html
-```markup
+```html
 <template>
   <section>
     <h2>${heading}</h2>
@@ -201,7 +201,7 @@ Alrighty. Time to configure the router. It's easy. You can set a title to use wh
 
 ### app.html
 
-```markup
+```html
 <template>
   <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="navbar-header">
@@ -316,7 +316,7 @@ There's a second lifecycle hook demonstrated here as well: `canDeactivate`. The 
 
 ### flickr.html
 
-```markup
+```html
 <template>
     <section>
         <h2>${heading}</h2>
@@ -348,7 +348,7 @@ Look at you, you overachiever! I see you're interested in learning some extra aw
 
 ### app.html
 
-```markup
+```html
 <template>
   <import from='./nav-bar'></import>
 
@@ -378,7 +378,7 @@ To create a custom element, you create and export a class. Since this class is g
 
 ### nav-bar.html
 
-```markup
+```html
 <template>
   <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="navbar-header">
@@ -417,7 +417,7 @@ This is a very simple custom element with no real behavior, but it is complete a
 
 ### app.html
 
-```markup
+```html
 <template>
   <import from='./nav-bar'></import>
 

--- a/Japanese/get-started.md
+++ b/Japanese/get-started.md
@@ -50,7 +50,7 @@
 今までの手順を実行していれば、あなたはすべてのライブラリ、ビルド設定など、AureliaですごいJavaScriptアプリケーションを作るために必要なすべてのツールを揃えたことになります。次に必要なことはプロジェクトフォルダのルートに_index.html_ファイルを作成することです。ファイルを作成し、下記のマークアップを使ってください。
 
 ### index.html
-```markup
+```html
 <!doctype html>
 <html>
   <head>
@@ -119,7 +119,7 @@ export class Welcome{
 オッケー。これで基本的なデータと振る舞いのある_ビューモデル_が用意できました。次にいわば共犯者の..._ビュー_について見てみます。
 
 ### app.html
-```markup
+```html
 <template>
   <section>
     <h2>${heading}</h2>
@@ -200,7 +200,7 @@ Aureliaはアプリケーションのレンダリングに必要なUIコンポ�
 
 ### app.html
 
-```markup
+```html
 <template>
   <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="navbar-header">
@@ -315,7 +315,7 @@ Aureliaのルータは、ルートが変更されるたびにビュー·モデ�
 
 ### flickr.html
 
-```markup
+```html
 <template>
     <section>
         <h2>${heading}</h2>
@@ -347,7 +347,7 @@ Aureliaのルータは、ルートが変更されるたびにビュー·モデ�
 
 ### app.html
 
-```markup
+```html
 <template>
   <import from='./nav-bar'></import>
 
@@ -377,7 +377,7 @@ export class NavBar {
 
 ### nav-bar.html
 
-```markup
+```html
 <template>
   <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="navbar-header">
@@ -416,7 +416,7 @@ export class NavBar {
 
 ### app.html
 
-```markup
+```html
 <template>
   <import from='./nav-bar'></import>
 

--- a/Spanish/docs.md
+++ b/Spanish/docs.md
@@ -157,7 +157,7 @@ Ahora, cada vez que se le solicita al contenedor de inyección de dependencias u
 
 El motor de plantillas de Aurelia es responsable de cargar las vistas y sus recursos importados, compilando tu HTML para un rendimiento óptimo y mostrando la interfaz de usuario (UI) en pantalla. Para crear una vista, todo lo que tienes que hacer es escribir un archivo HTML que incluya un `HTMLTemplate`. Aquí tienes una vista sencilla:
 
-```markup
+```html
 <template>
     <div>Hello World!</div>
 </template>
@@ -165,7 +165,7 @@ El motor de plantillas de Aurelia es responsable de cargar las vistas y sus recu
 
 Todo lo que esté dentro de una etiqueta `template` será manejado por Aurelia. En todo caso, puesto que Aurelia usa la tecnología HTMLImport para cargar las vistas, también puedes incluir _links_ -enlaces-, que serán correctamente cargados, incluyendo semántica de resolución de recursos relativos. En otras palabras, puedes hacer esto:
 
-```markup
+```html
 <link rel="stylesheet" type="text/css" href="./hello.css">
 
 <template>
@@ -177,7 +177,7 @@ De paso, esto te permite cargar dinámicamente hojas de estilo dependiendo de la
 
 Cada vez que quieras importar un recurso específico de Aurelia, ya sea un _Custom Element_ -elemento a medida-, _Attached Behavior_ -comportamiento añadido-, _Template Controller_ -control de plantillas- o _Value Converter_ -conversor de valores-, puedes usar en su lugar un elemento `import` dentro de tu vista. Aquí tienes un ejemplo:
 
-```markup
+```html
 <template>
   <import from='./nav-bar'></import>
 
@@ -218,7 +218,7 @@ _¿Pero que significa esto?_
 
 Enlace uni-direccional significa que los cambios fluyen de tus modelos (de vista) Javascript hacia la vista, y no de la vista hacia el modelo. Enlace bi-direccional significa que los cambios fluyen en ambas direcciones. `.bind` intenta usar un supuesto razonable al asumir que si estás estableciendo un enlace con el valor de una propiedad en un elemento de formulario, entonces probablemente querrás que los cambios realizados en el formulario fluyan hacia el modelo. Para todo lo demás usa un enlazado uni-direccional, especialmente teniendo en cuenta que frecuentemente carece de sentido el enlace bi-direccional para elementos que no son de formulario. Aquí tienes un pequeño ejemplo de enlazado usando `.bind`:
 
-```markup
+```html
 <input type="text" value.bind="firstName">
 <a href.bind="url">Aurelia</a>
 ```
@@ -227,7 +227,7 @@ En el ejemplo anterior, el elemento `input` tendrá su `value` -valor- vinculado
 
 Aunque siempre puedes ser explícito y usar `.one-way` o `.two-way` en lugar de `.bind`. Un caso común en que se requiere esto es con los componentes web -Web Components- que funcionan como controles de tipo input. Asi que podrás imaginarte haciendo algo como esto:
 
-```markup
+```html
 <markdown-editor value.two-way="markdown"></markdown-editor>
 ```
 
@@ -237,13 +237,13 @@ En orden a optimizar el rendimiento y minimizar el uso de CPU y de memoria, pued
 
 Las órdenes de enlace no solo sirven para conectar propiedades y atributos, sino que se pueden usar para lanzar comportamientos. Por ejemplo, para invocar un método en el modelo cuando se pulsa un botón de la vista, usarías la orden `trigger` de la siguiente manera:
 
-```markup
+```html
 <button click.trigger="sayHello()">Say Hello</button>
 ```
 
 Cuando se pulsa el botón, se invoca el método `sayHello` en el modelo. Dicho esto, no resulta muy eficiente añadir gestores de eventos a cada elemento por separado, así que con frecuencia desearás emplear la delegación de evento -event delegation-. Para ello, usa la orden `.delegate`. Aquí está el mismo ejemplo, pero con delegación de evento:
 
-```markup
+```html
 <button click.delegate="sayHello()">Say Hello</button>
 ```
 
@@ -251,7 +251,7 @@ Cuando se pulsa el botón, se invoca el método `sayHello` en el modelo. Dicho e
 
 Todo esto va de una u otra manera en contra de los eventos de DOM. Ocasionalmente puedes encontrarte con un comportamiento a medida de Aurelia que necesite directamente una referencia a tu función de forma que pueda ser invocada posteriormente. Para pasar una referencia de función, usa el enlazador `.`call` (puesto que el comportamiento la _llamará -call-_ más tarde):
 
-```markup
+```html
 <div touch.call="sayHello()">Say Hello</button>
 ```
 
@@ -261,13 +261,13 @@ Ahora el comportamiento asociado recibirá una función que podrá llamar para i
 
 A veces necesitas vincular propiedades directamente dentro del contenido del documento o intercalarlas dentro de un valor de atributo. Para ello puedes usar la sintaxis para interpolación de cadenas  `${expresión}`. La interpolación de cadenas es un enlace uni-direccional cuya salida es convertida en una cadena. Aquí tienes un ejemplo:
 
-```markup
+```html
 <span>${fullName}</span>
 ```
 
 La propiedad `fullName` será directamente interpolada en el contenido del (elemento) `span`. También puedes usar la interpolación de cadenas para manipular enlaces a clases CSS así:
 
-```markup
+```html
 <div class="dot ${color} ${isHappy ? 'green' : 'red'}"></div>
 ```
 
@@ -279,13 +279,13 @@ En esta linea "dot" es una clase presente estáticamente y "green" solo está pr
 
 Además de órdenes e interpolación, el lenguaje de enlazado reconoce el uso de un atributo especial: `ref`. Al usar `ref` puedes crear un nombre local para un elemento que podrás usar como referencia en otra expresión de enlace. También se añadirá como una propiedad en el modelo, de manera que será accesible a través de código. Aquí tienes un ejemplo claro del uso de `ref`:
 
-```markup
+```html
 <input type="text" ref="name"> ${name.value}
 ```
 
 También puedes usar el enlace especial `.view-model` combinado con `ref` para obtener el objeto de tipo modelo que respalda un elemento a medida de Aurelia. Mediante esta técnica puedes vincular diferentes componentes entre si de la siguiente manera:
 
-```markup
+```html
 <i-produce-a-value ref.view-model="producer"></i-produce-a-value>
 <i-consume-a-value input.bind="producer.output"></i-consume-a-value>
 ```
@@ -304,7 +304,7 @@ Naturalmente, todos funcionan sin problemas con el enlazado de datos. Echemos un
 
 El comportamiento añadido `show` te permite condicionar la visualización de un elemento HTML. Si el valor de `show` es `true` el elemento se visualiza el elemento, en caso contrario se mantiene oculto. Este comportamiento no añade/elimina el elemento del DOM, solo modifica su visibilidad. Aquí tienes un ejemplo:
 
-```markup
+```html
 <div show.bind="isSaving" class="spinner"></div>
 ```
 
@@ -314,7 +314,7 @@ Cuando la propiedad `isSaving` es verdadera, el `div` será visible, en caso con
 
 El control de plantillas `if` permite añadir/eliminar un elemento HTML condicionalmente. Si el valor es verdadero, el elemento estará presente en el DOM, en caso contrario no.
 
-```markup
+```html
 <div if.bind="isSaving" class="spinner"></div>
 ```
 
@@ -322,7 +322,7 @@ Este ejemplo es parecido al anterior con `show`. La diferencia estriba en que si
 
 Si necesitas añadir/eliminar condicionalmente un grupo de elementos y no puedes colocar el comportamiento -behavior- `if` en un elemento padre, entonces puedes envolver esos elementos en una etiqueta `template` que incluya el comportamiento `if`. Así es como quedaría:
 
-```markup
+```html
 <template if.bind="hasErrors">
     <i class="icon error"></i>
     ${errorMessage}
@@ -333,7 +333,7 @@ Si necesitas añadir/eliminar condicionalmente un grupo de elementos y no puedes
 
 El control de plantillas `repeat` te permite mostrar una plantilla varias veces, una por cada elemento de un vector. Aquí tienes un ejemplo que muestra la lista de nombres de clientes:
 
-```markup
+```html
 <ul>
     <li repeat.for="customer of customers">${customer.fullName}</li>
 </ul>
@@ -347,7 +347,7 @@ Una consideración importante acerca del comportamiento `repeat` es que trabaja 
 
 El elemento a medida `compose` te capacita para mostrar dinámicamente interfaz de usuario dentro del DOM. Imagínate que tienes un vector heterogéneo de elementos, pero que cada uno tiene una propiedad `type` que nos dice que es lo que es. Entonces puedes hacer algo así:
 
-```markup
+```html
 <template repeat.for="item of items">
     <compose
       model.bind="item"
@@ -366,7 +366,7 @@ El elemento `compose` también tiene un atributo `view` que puede ser usado de l
 
 HTMLSelectElement es una bestia interesante. Usualmente, puedes enlazar estos datos combinando un `repeat` para las opciones con un enlace con el valor, como esto:
 
-```markup
+```html
 <select value.bind="favoriteNumber">
     <option>Select A Number</option>
     <option repeat.for="number of numbers" value.bind="number">${number}</option>
@@ -375,7 +375,7 @@ HTMLSelectElement es una bestia interesante. Usualmente, puedes enlazar estos da
 
 Pero a veces deseas trabajar con objetos del tipo selector en lugar de primitivas. Para ello puedes usar el comportamiento añadido `selected-item`. Aquí está como configurar esto para una teórica lista de empleados:
 
-```markup
+```html
 <select selected-item.bind="employeeOfTheMonth">
   <option>Select An Employee</option>
   <option repeat.for="employee of employees" value.bind="employee.id" model.bind="employee">${employee.fullName}</option>
@@ -390,7 +390,7 @@ Primero, especificamos la orden de enlace `.bind` para el `selected-item`. Luego
 
 Este no es un comportamiento añadido que vayas a usar directamente. En lugar de eso, este funciona en conjunción con una orden de enlace a medida para habilitar dinámicamente el uso declarativo de los complementos jQuery y otras APIs similares en HTML. Veamos un ejemplo para clarificar la idea:
 
-```markup
+```html
 <div jquery.modal="show: true; keyboard.bind: allowKeyboard">...</div>
 ```
 
@@ -449,7 +449,7 @@ Así que, que opciones tienes para el patrón del sistema de gestión de rutas?
 
 Todas las rutas con una propiedad `nav` verdadera se recogen en un vector `navigation`. Esto hace realmente sencillo usar el enlace de datos para generar una estructura de menú. Otra propiedad importante para el enlazado es la propiedad `isNavigating`. Aquí  tienes un sencillo marcado que muestra lo que podría emparejarse con el modelo mostrado arriba:
 
-```markup
+```html
 <template>
   <ul>
     <li class="loader" if.bind="router.isNavigating">
@@ -687,7 +687,7 @@ Los comportamientos añadidos tienden a representar competencias transversales. 
 
 Veamos la implementación de uno de los comportamientos añadidos (propios) de Aurelia: `show`. Aquí tienes como se usa:
 
-```markup
+```html
 <div show.bind="isSaving" class="spinner"></div>
 ```
 
@@ -778,7 +778,7 @@ export class Show {
 
 Esto crea un comportamiento añadido de nombre `my-behavior` con dos propiedades `foo` and `bar`. Cada una de estas propiedades están disponibles directamente en la clase, aunque su configuración en HTML es algo distinta. Aquí está como lo haríamos:
 
-```markup
+```html
 <div my-behavior="foo: some literal value; bar.bind: some.expression"></div>
 ```
 
@@ -792,7 +792,7 @@ Los elementos a medida añaden nuevas etiquetas a tu marcado HTML. Cada elemento
 
 ¿Por qué no creamos un sencillo elemento a medida para ver como funciona esto? Vamos a crear un elemento que salude a alguien, llamado `say-hello`. Aquí está como queremos poder usarlo una vez que esté hecho:
 
-```markup
+```html
 <template>
     <import from="./say-hello"></import>
 
@@ -840,7 +840,7 @@ export class SayHelloCustomElement {
 Por defecto, los elementos a medida tienen una vista. Aquí está la del nuestro:
 
 #### say-hello.html
-```markup
+```html
 <template>
     <button click.delegate="speak()">Say Hello To ${to}</button>
 </template>

--- a/Spanish/get-started.md
+++ b/Spanish/get-started.md
@@ -50,7 +50,7 @@ Hasta aquí todo lo que hemos hecho son procedimientos Node.js normales de monta
 Si nos has seguido hasta aquí, ahora dispones de todas las librerías, configuración de montaje y herramientas necesarias para crear aplicaciones sorprendentes con Aurelia. Lo próximo que has de hacer es crear el archivo _index.html_ en la raíz de nuestra carpeta de proyecto. Créalo ahora y utiliza el código que viene a continuación.
 
 ### index.html
-```markup
+```html
 <!doctype html>
 <html>
   <head>
@@ -119,7 +119,7 @@ Si. Lo es. De hecho es ECMAScript 6 (ES6), la próxima versión de Javascript qu
 Bien. Ahora que tenemos un modelo (de vista) con algunos datos y comportamiento básicos, echemos un vistazo a su cómplice... la vista. 
 
 ### app.html
-```markup
+```html
 <template>
   <section>
     <h2>${heading}</h2>
@@ -201,7 +201,7 @@ Muy bien. Toca configurar el enrutador. Es sencillo. Puedes incluir un título q
 
 ### app.html
 
-```markup
+```html
 <template>
   <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="navbar-header">
@@ -316,7 +316,7 @@ Hay un segundo gancho en el ciclo de vida que aparece aquí: `canDeactive`. El e
 
 ### flickr.html
 
-```markup
+```html
 <template>
     <section>
         <h2>${heading}</h2>
@@ -348,7 +348,7 @@ Recapitulemos. Para añadir una página a nuestra aplicación:
 
 ### app.html
 
-```markup
+```html
 <template>
   <import from='./nav-bar'></import>
 
@@ -378,7 +378,7 @@ Para crear un elemento a medida, has de crear y exportar una clase. Puesto que e
 
 ### nav-bar.html
 
-```markup
+```html
 <template>
   <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="navbar-header">
@@ -417,7 +417,7 @@ Este es un elemento a medida muy simple sin ningún comportamiento real, pero es
 
 ### app.html
 
-```markup
+```html
 <template>
   <import from='./nav-bar'></import>
 


### PR DESCRIPTION
I am not sure if the `markup` tag was intended, if not I changed it to `html` so that users browsing the markdown files in GitHub could see proper HTML styling for improved readability.