### PR TITLE
fix(IE9): update docs for IE9 support

### DIFF
--- a/English/docs.md
+++ b/English/docs.md
@@ -6,17 +6,21 @@ We've got a very rich set of docs planned for Aurelia. Unfortunately, we haven't
 
 <h2 id="browser-support"><a href="#browser-support">Browser Support</a></h2>
 
-Aurelia was originally designed for Evergreen Browsers. This includes Chrome, Firefox, IE11 and Safari 8. However, we have identified how to support IE9 and above. To make this work, you need to add two additional polyfills: MutationObservers and WeakMap. This can be achieved by a jspm install of `github:webreflection/es6-collections` and `github:polymer/mutationobservers`. Load these two scripts before system.js.
-
-Your index.html will look like this:
+Aurelia was originally designed for Evergreen Browsers. This includes Chrome, Firefox, IE11 and Safari 8. However, we have identified how to support IE9 and above. To make this work, you need to add an additional polyfill for MutationObservers. This can be achieved by a jspm install of `github:polymer/mutationobservers`. Then wrap the call to `aurelia-bootstrapper` as follows:
 
 ```markup
-<script src="jspm_packages/github/webreflection/es6-collections@master/es6-collections.js"></script>
 <script src="jspm_packages/github/polymer/mutationobservers@0.4.2/MutationObserver.js"></script>
 <script src="jspm_packages/system.js"></script>
 <script src="config.js"></script>
 <script>
-  System.import('aurelia-bootstrapper');
+  // Loads WeakMap polyfill needed by MutationObservers
+  System.import('core-js').then( function() {
+    // Imports MutationObserver polyfill
+    System.import('mutationobservers').then( function() {
+      // Ensures start of Aurelia when all required IE9 dependencies are loaded
+      System.import('aurelia-bootstrapper');
+    })
+  });
 </script>
 ```
 


### PR DESCRIPTION
This adds the updated information on how to use Aurelia with IE9, note that we are down to only one additional polyfill