### PR TITLE
Without `title` item doesn't show in menu

### DIFF
--- a/English/get-started.md
+++ b/English/get-started.md
@@ -271,7 +271,7 @@ export class App {
     config.title = 'Aurelia';
     config.map([
       { route: ['','welcome'], name: 'welcome',  moduleId: './welcome',      nav: true, title:'Welcome' },
-      { route: 'flickr',       name: 'flickr',   moduleId: './flickr',       nav: true }
+      { route: 'flickr',       name: 'flickr',   moduleId: './flickr',       nav: true, title:'Flickr' }
     ]);
 
     this.router = router;


### PR DESCRIPTION
I don't know if `title` was intentionally left out to show that it's optional. But without `title` the item doesn't show up in the menu.