### PR TITLE
Adding mention on how to authorize jspm without giving github password

### DIFF
--- a/English/get-started.md
+++ b/English/get-started.md
@@ -20,9 +20,11 @@ Next, we need to install [jspm](http://jspm.io/). This will serve as our client-
   npm install -g jspm@beta
   ```
 
-> **Note:** jspm, like Bower and Yeoman, leverages [git](http://git-scm.com/) so you need to install that if you don't have it. Also, jspm queries GitHub to install packages, but GitHub has a rate limit on anonymous API requests. It is advised that you configure jspm with your GitHub credentials in order to avoid problems. You can do this by executing `jspm registry config github` and following the prompts. Don't want to use jspm? No problem. All Aurelia packages are available via [Bower](http://bower.io/) as well.
+> **Note:** jspm, like Bower and Yeoman, leverages [git](http://git-scm.com/) so you need to install that if you don't have it. Also, jspm queries GitHub to install packages, but GitHub has a rate limit on anonymous API requests. It is advised that you configure jspm with your GitHub credentials in order to avoid problems. You can do this by executing `jspm registry config github` and following the prompts. If you choose to authorize jspm by an access token instead of giving your password (see GitHub `Settings > Personal Access Tokens`), `public_repo` access for the token is required.
 
 > **Note:** Once the jspm beta becomes the mainline release, you will no longer need the `@beta`.
+
+> **Note:** Don't want to use jspm? No problem. All Aurelia packages are available via [Bower](http://bower.io/) as well.
 
 ## Setting up the Project Structure and Build
 


### PR DESCRIPTION
Change requested by @zewa666 here: https://github.com/aurelia/skeleton-navigation/pull/135#issuecomment-130190502

Note: Moved the mention about Bower below all the jspm text. I believe this eases readability.