### PR TITLE
docs(getting-started): Removing JSPM beta installation instruction

### DIFF
--- a/English/get-started.md
+++ b/English/get-started.md
@@ -17,12 +17,10 @@ First, let's begin by installing [Gulp](http://gulpjs.com/) which we'll be using
 Next, we need to install [jspm](http://jspm.io/). This will serve as our client-side package manager. You can do that like this:
 
   ```shell
-  npm install -g jspm@beta
+  npm install -g jspm
   ```
 
 > **Note:** jspm, like Bower and Yeoman, leverages [git](http://git-scm.com/) so you need to install that if you don't have it. Also, jspm queries GitHub to install packages, but GitHub has a rate limit on anonymous API requests. It is advised that you configure jspm with your GitHub credentials in order to avoid problems. You can do this by executing `jspm registry config github` and following the prompts. If you choose to authorize jspm by an access token instead of giving your password (see GitHub `Settings > Personal Access Tokens`), `public_repo` access for the token is required.
-
-> **Note:** Once the jspm beta becomes the mainline release, you will no longer need the `@beta`.
 
 > **Note:** Don't want to use jspm? No problem. All Aurelia packages are available via [Bower](http://bower.io/) as well.
 


### PR DESCRIPTION
The beta release of JSPM is now the stable release. As such, to install a compatible version of JSPM for working with Aurelia the"@beta" tag and instructional note is no longer needed.