### PR TITLE
fix <option> model.bind

### DIFF
--- a/English/docs.md
+++ b/English/docs.md
@@ -513,7 +513,7 @@ A typical select element is rendered using a combination of `value.bind` and `re
 ```markup
 <select value.bind="favoriteColor">
     <option>Select A Color</option>
-    <option repeat.for="color of colors" value.bind="color">${color}</option>
+    <option repeat.for="color of colors" model.bind="color">${color}</option>
 </select>
 ```
 
@@ -543,7 +543,7 @@ You can bind the select element's value to an array property in multi-select sce
 
 ```markup
 <select value.bind="favoriteColors" multiple>
-    <option repeat.for="color of colors" value.bind="color">${color}</option>
+    <option repeat.for="color of colors" model.bind="color">${color}</option>
 </select>
 ```
 

--- a/Spanish/docs.md
+++ b/Spanish/docs.md
@@ -393,7 +393,7 @@ Un típico elemento select se muestra usando una combinación de `value.bind` y 
 ```markup
 <select value.bind="favoriteColor">
     <option>Select A Color</option>
-    <option repeat.for="color of colors" value.bind="color">${color}</option>
+    <option repeat.for="color of colors" model.bind="color">${color}</option>
 </select>
 ```
 
@@ -414,7 +414,7 @@ Puedes enlazar el valor del elemento select a una propiedad vector en un escenar
 
 ```markup
 <select value.bind="favoriteColors" multiple>
-    <option repeat.for="color of colors" value.bind="color">${color}</option>
+    <option repeat.for="color of colors" model.bind="color">${color}</option>
 </select>
 ```
 


### PR DESCRIPTION
Don't know what the intent is, but value.bind on <option> sure don't work, so I assume it should be model.bind.

I first noticed this on the cheat sheet on aurelia.io; apologies for not tracking down where that document lives.