### PR TITLE
doc (create-a-contact-manager): Removed redundant class on form group

### DIFF
--- a/current/en-us/2. tutorials/2. creating-a-contact-manager.md
+++ b/current/en-us/2. tutorials/2. creating-a-contact-manager.md
@@ -435,7 +435,7 @@ With that all in place, let's look at the view that will render this component. 
     </div>
     <div class="card-body">
       <form role="form">
-        <div class="form-group row">
+        <div class="form-group">
           <label class="col-sm-3 col-form-label">First Name</label>
           <div class="col-sm-9">
             <input type="text" placeholder="first name" class="form-control" value.bind="contact.firstName">


### PR DESCRIPTION
Removed redundant `row` class from the `first-name` form group to improve conciseness.

Closes issue [#363](https://github.com/aurelia/documentation/issues/363)