### PR TITLE
Update 5. cheat-sheet.md

### DIFF
--- a/current/en-us/3. fundamentals/5. cheat-sheet.md
+++ b/current/en-us/3. fundamentals/5. cheat-sheet.md
@@ -264,6 +264,9 @@ export class CustomerDetail {
 > Info: Invalid Table Structure When Dynamically Creating Tables
 > When the browser loads in the template it very helpfully validates the structure of the HTML, notices that you have an invalid tag inside your table definition, and very unhelpfully removes it for you before Aurelia even has a chance to examine your template.
 
+> Warning: webpack
+> Dynamic compose as used below does not work when using webpack. It is suggested to bind to a property on the viewmodel `template: PLATFORM.moduleName("./template_${r}.html")` and then use it like so `<tr repeat.for="r of ['A','B','A','B']" as-element="compose" view.bind='template'>`
+
 Use of the `as-element` attribute ensures we have a valid HTML table structure at load time, yet we tell Aurelia to treat its contents as though it were a different tag.
 
 ```HTML Compose an existing object instance with a view.


### PR DESCRIPTION
The solution proposed and documented here https://github.com/aurelia/templating/issues/261 did not work for me. This was due to webpack not supporting dynamic compose https://github.com/aurelia/skeleton-navigation/issues/810. @jods4 proposed to bind to a property on the viewmodel that uses `PLATFORM.moduleName` which does then allow the solution to work. This update is to just give a heads up to anyone reading the cheatsheet that is using webpack.