### PR TITLE
docs(virtualization): formatting and typos

### DIFF
--- a/current/en-us/7. plugins/7. virtualization.md
+++ b/current/en-us/7. plugins/7. virtualization.md
@@ -8,7 +8,7 @@ author: Dwayne Charrington (https://ilikekillnerds.com)
 
 When dealing with large collections of items (thousands, upwards of tens of thousands), whether that be an array or map, certain challenges come with displaying those items in a performant manner due to DOM constraints. This is where the UI Virtualization plugin comes in very handy.
 
-This plugin enables "virtualization" of list through a new virtual-repeat.for. When used, the list "virtually" as tens or hundreds of thousands of rows, but the DOM only actually has rows for what is visible. It could be only tens of items. This allows rendering of massive lists of data with amazing performance. It works like repeat.for, it just creates a scrolling area and manages the list using UI virtualization techniques.
+This plugin enables "virtualization" of lists through a new virtual-repeat.for attribute. When used, the list "virtually" has tens or hundreds of thousands of rows, but the DOM only has rows for what is visible. This allows rendering of massive lists of data with amazing performance. It works like repeat.for, it just creates a scrolling area and manages the list using UI virtualization techniques.
 
 ## Installing The Plugin
 
@@ -148,7 +148,7 @@ The infinite-scroll-next attribute can accept a function, a promise, or a functi
 
 ## Caveats
 
-1. `<template/>` is not supported as root element of a virtual repeat template, because virtualization requires item heights to be calculatable. With `<tempate/>`, there is no easy and performant way to acquire this value.
+1. `<template/>` is not supported as a root element of a virtual repeat template, because virtualization requires item heights to be calculatable. With `<tempate/>`, there is no easy and performant way to acquire this value.
 2. Similar to (1), other template controllers cannot be used in conjunction with 1virtual-repeat1, unlike repeat i.e: built-in template controllers: `with`, `if`, `replaceable` cannot be used with `virtual-repeat`. You can easily work around this constraint by nesting other template controllers inside the repeated element, with `<template/>` element, for example:
 
 ```Html app.html


### PR DESCRIPTION
Cleaned up some of the copied text from the plugin README which had a few typos and grammatical errors.