### PR TITLE
Adding documentation on `@processContent`

### DIFF
--- a/current/en-us/5. templating/4. custom-elements.md
+++ b/current/en-us/5. templating/4. custom-elements.md
@@ -378,3 +378,55 @@ There are lots of options that allow you to change how custom elements work. The
 * `@useShadowDOM()` - Causes the view to be rendered in the ShadowDOM. When an element is rendered to ShadowDOM, a special `DOMBoundary` instance can optionally be injected into the constructor. This represents the shadow root.
 * `@containerless()` - Causes the element's view to be rendered without the custom element container wrapping it. This cannot be used in conjunction with `@child`, `@children` or `@useShadowDOM` decorators. It also cannot be used with surrogate behaviors. Use sparingly.
 * `@viewResources(...dependencies)` - Adds dependencies to the underlying View. Same as: `<require from="..."></require>`, but declared in the ViewModel. Arguments can either be strings with `moduleId`s, `Object`s with `src` and optionally `as` properties, or classes of the module to be included.
+
+### Examples: Show me the code!!
+
+The utility of some of these decorators is immediately evident from the description. However, that may not be the case for some of involved ones. Thus, in this section we would like to show some simple examples to portray the usefulness of some of these decorators. Some of these examples are even silly (why? for the sake of science!), but we trust you can put those for better usage!
+
+#### Display Aurelia template fragment in your Aurelia app using `@processContent`, and `@noView`
+Suppose we want to display the following template fragment in our app.
+
+```HTML
+<span>${message}</span>
+```
+
+A naive approach would be to use something like below.
+
+```HTML app.html
+<template>
+  <pre>
+    <code>
+      &lt;span&gt;${message}&lt;/span&gt;
+    </code>
+  </pre>
+</template>
+```
+
+But with that Aurelia will perform string interpolation for `${message}`, and depending on whether or not the view-model has a `message` property/data-member, the app wll display the value of `message` or nothing. But that was not intended. To shows such code fragments, we can create a no-op custom element to wrap such code fragments.
+
+```TypeScript CodeFragment.ts
+import { noView, processContent } from "aurelia-framework";
+
+@noView()
+@processContent(false)
+export class CodeFragment {}
+```
+
+```HTML app.html
+<template>
+  <require from="./CodeFragment"></require>
+  <code-fragment>
+    <pre>
+      <code>
+        &lt;span&gt;${message}&lt;/span&gt;
+      </code>
+    </pre>
+  </code-fragment>
+</template>
+```
+
+When Aurelia compiles the `code-fragment` part of the view it does not look for a view for `CodeFragment` as the class is decorated with `@noView()`. Also it does not process any content that comes between `<code-fragment>` and `</code-fragment>`, as instructed by `@processContent(false)`. You can see the result below.
+
+[noView, processContent demo](https://codesandbox.io/s/o590zjlwq9?autoresize=1&fontsize=18&hidenavigation=1&module=%2Fsrc%2Fapp.html&view=preview)
+
+So, go ahead and create the documentation app you always wanted to have, to show-case the usage of your own custom elements library.

--- a/current/en-us/5. templating/4. custom-elements.md
+++ b/current/en-us/5. templating/4. custom-elements.md
@@ -639,7 +639,7 @@ You maybe thinking that "all that is okay, but how the heck can I use my awesome
 
 ```HTML TabHeader.html
 <template>
-	<button class="btn btn-link" class.bind="isActive?'active':''" click.delegate="tabSelector()">
+  <button class="btn btn-link" class.bind="isActive?'active':''" click.delegate="tabSelector()">
     ${name}
   </button>
 </template>

--- a/current/en-us/5. templating/4. custom-elements.md
+++ b/current/en-us/5. templating/4. custom-elements.md
@@ -402,9 +402,10 @@ A naive approach would be to use something like below.
 </template>
 ```
 
-But with that Aurelia will perform string interpolation for `${message}`, and depending on whether or not the view-model has a `message` property/data-member, the app wll display the value of `message` or nothing. But that was not intended. To shows such code fragments, we can create a no-op custom element to wrap such code fragments.
+But with that Aurelia will perform string interpolation for `${message}`, and depending on whether or not the view-model has a `message` property/data-member, the app will display the value of `message` or nothing. But that was not intended. To shows such code fragments, we can create a no-op custom element to wrap such code fragments.
 
 ```TypeScript CodeFragment.ts
+// reference: https://stackoverflow.com/a/50066210/2270340 
 import { noView, processContent } from "aurelia-framework";
 
 @noView()
@@ -430,3 +431,110 @@ When Aurelia compiles the `code-fragment` part of the view it does not look for 
 [noView, processContent demo](https://codesandbox.io/s/o590zjlwq9?autoresize=1&fontsize=18&hidenavigation=1&module=%2Fsrc%2Fapp.html&view=preview)
 
 So, go ahead and create the documentation app you always wanted to have, to show-case the usage of your own custom elements library.
+
+#### Pretty looking template for your Tabs control
+When we want to create our own custom element for a Tabs control, it is much compact and intuitive if we can use the element as follows.
+
+```HTML
+<tabs>
+  <tab header="IMDB's Top 250 Movies">
+    <ul>
+      <li>The Shawshank Redemption</li>
+      <li>The Godfather</li>
+      <li>The Godfather: Part II</li>
+      <li>The Dark Knight</li>
+      <li>12 Angry Men</li>
+      <li>...</li>
+    </ul>
+  </tab>
+  <tab header="IMDB's Top 250 TV Shows">
+    <ul>
+      <li>Planet Earth II</li>
+      <li>Band of Brothers</li>
+      <li>Game of Thrones</li>
+      <li>Planet Earth</li>
+      <li>Breaking Bad</li>
+      <li>...</li>
+    </ul>
+  </tab>
+  <tab header="Recently Added">
+    Nothing to see here.
+  </tab>
+</tabs>
+```
+This way the tab header and the respective content stays together. Thus, reordering the tabs becomes easier, without accidentally showing wrong content under under unrelated header. However, the rendered DOM for such tabs is usually (refer [Bootstrap Tabs](https://getbootstrap.com/docs/4.2/components/navs/#javascript-behavior)) like following, where we have separate a section for tab header in form of `ul>li` and a separate section for the content.
+
+```HTML
+<ul>
+  <li><a>IMDB's Top 250 Movies</a></li>
+  <li><a>IMDB's Top 250 TV Shows</a></li>
+  <li><a>Recently Added</a></li>
+</ul>
+<div>
+  <div>...</div>
+  <div>...</div>
+  <div>...</div>
+</div>
+```
+We can use `@processContent` decorator along with a function to achieve this. Following is a minimal implementation to start things simple.
+
+```HTML app.html
+<template>
+	<require from="./Tabs"></require>
+	<tabs>
+		<tab header="Top Movies"></tab>
+		<tab header="Top TV Shows"></tab>
+		<tab header="Recently Added"></tab>
+	</tabs>
+</template>
+```
+
+```HTML Tabs.html
+<template>
+	<slot></slot>
+</template>
+```
+
+```TypeScript Tabs.ts
+import { processContent } from "aurelia-framework";
+
+function processTabs(compiler, resources, node, instruction) {
+  const headers = document.createElement("div");
+  const tabs = Array.from(node.querySelectorAll("tab"));
+
+  for (const tab of tabs) {
+    const header = tab.getAttribute("header");
+
+    const tabHeader = document.createElement("button");
+    tabHeader.innerText = header;
+    tabHeader.classList = "btn btn-link";
+
+    headers.appendChild(tabHeader);
+    node.removeChild(tab);
+  }
+
+  node.appendChild(headers);
+}
+
+@processContent(processTabs)
+export class Tabs {}
+```
+
+The function used in `@processContent` takes four arguments, out of which `node` is the most important for this discussion. In this case, `node` is basically holds the DOM fragment for `<tabs>...</tabs>` used in `app.html` And then in this function, we do nothing but pure DOM manipulation, which transforms the original DOM fragment to something like below. You can checkout the result as well as play with the example in the embedded code sandbox.
+
+```HTML 
+<tabs>
+  <div>
+    <button class="btn btn-link">Top Movies</button>
+    <button class="btn btn-link">Top TV Shows</button>
+    <button class="btn btn-link">Recently Added</button>
+  </div>
+  <tab header="Tab 1"></tab>
+  <tab header="Tab 2"></tab>
+  <tab header="Tab 3"></tab>
+</tabs>
+```
+[simple tab demo](https://codesandbox.io/s/r5v171o1wo?autoresize=1&hidenavigation=1&module=%2Fsrc%2FTabs.js&view=preview)
+
+<!-- TODO add tab content and click.delegate binding -->
+<!-- TODO show how to use custom element -->

--- a/current/en-us/5. templating/4. custom-elements.md
+++ b/current/en-us/5. templating/4. custom-elements.md
@@ -402,7 +402,7 @@ A naive approach would be to use something like below.
 </template>
 ```
 
-But with that Aurelia will perform string interpolation for `${message}`, and depending on whether or not the view-model has a `message` property/data-member, the app will display the value of `message` or nothing. But that was not intended. To shows such code fragments, we can create a no-op custom element to wrap such code fragments.
+But with that Aurelia will perform string interpolation for `${message}`, and depending on whether or not the view-model has a `message` property/data-member, the app will display the value of `message` or nothing. But that was not intended. To show such code fragments, we can create a no-op custom element to wrap such code fragments.
 
 ```TypeScript CodeFragment.ts
 // reference: https://stackoverflow.com/a/50066210/2270340 
@@ -462,7 +462,7 @@ When we want to create our own custom element for a Tabs control, it is much com
   </tab>
 </tabs>
 ```
-This way the tab header and the respective content stays together. Thus, reordering the tabs becomes easier, without accidentally showing wrong content under under unrelated header. However, the rendered DOM for such tabs is usually (refer [Bootstrap Tabs](https://getbootstrap.com/docs/4.2/components/navs/#javascript-behavior)) like following, where we have separate a section for tab header in form of `ul>li` and a separate section for the content.
+This way the tab header and the respective content stays together. Thus, reordering the tabs becomes easier, without accidentally showing wrong content under unrelated header. However, the rendered DOM for such tabs is usually (refer [Bootstrap Tabs](https://getbootstrap.com/docs/4.2/components/navs/#javascript-behavior)) like following, where we have a separate section for the tab header in form of `ul>li` and a separate section for the content.
 
 ```HTML
 <ul>
@@ -476,65 +476,307 @@ This way the tab header and the respective content stays together. Thus, reorder
   <div>...</div>
 </div>
 ```
-We can use `@processContent` decorator along with a function to achieve this. Following is a minimal implementation to start things simple.
+We can use `@processContent` decorator along with a function to achieve this. Following is a minimal implementation.
 
 ```HTML app.html
 <template>
-	<require from="./Tabs"></require>
-	<tabs>
-		<tab header="Top Movies"></tab>
-		<tab header="Top TV Shows"></tab>
-		<tab header="Recently Added"></tab>
-	</tabs>
+  <require from="./Tabs"></require>
+  <tabs>
+    <tab header="Top Movies">
+      <ul>
+        <li>The Shawshank Redemption</li>
+        <li>The Godfather</li>
+        <li>The Godfather: Part II</li>
+        <li>The Dark Knight</li>
+        <li>12 Angry Men</li>
+      </ul>
+    </tab>
+    <tab header="Top TV Shows">
+      <ul>
+        <li>Planet Earth II</li>
+        <li>Band of Brothers</li>
+        <li>Game of Thrones</li>
+        <li>Planet Earth</li>
+        <li>Breaking Bad</li>
+      </ul>
+    </tab>
+    <tab header="Recently Added"> Nothing to see here. </tab>
+  </tabs>
 </template>
 ```
 
 ```HTML Tabs.html
 <template>
-	<slot></slot>
+  <!-- Here we have 2 replaceable templates for header and content -->
+  <div><template replaceable part="header"></template></div>
+  <div><template replaceable part="content"></template></div>
 </template>
 ```
 
-```TypeScript Tabs.ts
-import { processContent } from "aurelia-framework";
+```JavaScript Tabs.js
+import { bindable, BindingEngine, Container, processContent } from "aurelia-framework";
 
 function processTabs(compiler, resources, node, instruction) {
-  const headers = document.createElement("div");
+  // first create 2 templates for the replaceable parts
+  const headerTemplate = document.createElement("template");
+  headerTemplate.setAttribute("replace-part", "header");
+  const contentTemplate = document.createElement("template");
+  contentTemplate.setAttribute("replace-part", "content");
+
+  // process all tabs
   const tabs = Array.from(node.querySelectorAll("tab"));
+  for (let i = 0; i < tabs.length; i++) {
+    const tab = tabs[i];
 
-  for (const tab of tabs) {
-    const header = tab.getAttribute("header");
+    // add header
+    const header = document.createElement("button");
+    header.classList.add("btn", "btn-link");
+    header.setAttribute("click.delegate", `showTab('${i}')`);
+    header.innerText = tab.getAttribute("header");
+    headerTemplate.content.appendChild(header);
 
-    const tabHeader = document.createElement("button");
-    tabHeader.innerText = header;
-    tabHeader.classList = "btn btn-link";
+    // add content
+    const content = document.createElement("div");
+    content.setAttribute("show.bind", `activeTabId=='${i}'`);
+    content.append(...Array.from(tab.childNodes));
+    contentTemplate.content.appendChild(content);
 
-    headers.appendChild(tabHeader);
     node.removeChild(tab);
   }
 
-  node.appendChild(headers);
+  // Activate the first tab
+  const bindingEngine = Container.instance.get(BindingEngine);
+  instruction.attributes = {
+    ...instruction.attributes,
+    "active-tab-id": bindingEngine.createBindingExpression("activeTabId", "'0'")
+  };
+
+  node.append(headerTemplate, contentTemplate);
+  return true;
 }
 
 @processContent(processTabs)
-export class Tabs {}
+export class Tabs {
+  @bindable activeTabId;
+  showTab(tabId) {
+    this.activeTabId = tabId;
+  }
+}
 ```
 
-The function used in `@processContent` takes four arguments, out of which `node` is the most important for this discussion. In this case, `node` is basically holds the DOM fragment for `<tabs>...</tabs>` used in `app.html` And then in this function, we do nothing but pure DOM manipulation, which transforms the original DOM fragment to something like below. You can checkout the result as well as play with the example in the embedded code sandbox.
+```TypeScript Tabs.ts [variant]
+import { BehaviorInstruction, bindable, BindingEngine, Container, processContent } from "aurelia-framework";
+
+@processContent(Tabs.processTabs)
+export class Tabs {
+  // A static method in the custom element class itself is more compact than an external function as shown the JavaScript version.
+  // But both serves same purpose.
+  public static processTabs(_compiler, _resources, node: HTMLElement, instruction: BehaviorInstruction) {
+    // first create 2 templates for the replaceable parts
+    const headerTemplate = document.createElement("template");
+    headerTemplate.setAttribute("replace-part", "header");
+    const contentTemplate = document.createElement("template");
+    contentTemplate.setAttribute("replace-part", "content");
+
+    // process all tabs
+    const tabs = Array.from(node.querySelectorAll("tab"));
+    for (let i = 0; i < tabs.length; i++) {
+      const tab = tabs[i];
+
+      // add header
+      const header = document.createElement("button");
+      header.setAttribute("click.delegate", `showTab('${i}')`);
+      header.innerText = tab.getAttribute("header");
+      headerTemplate.content.appendChild(header);
+
+      // add content
+      const content = document.createElement("div");
+      content.setAttribute("show.bind", `activeTabId=='${i}'`);
+      content.append(...Array.from(tab.childNodes));
+      contentTemplate.content.appendChild(content);
+
+      node.removeChild(tab);
+    }
+
+    // Activate the first tab
+    const bindingEngine: BindingEngine = Container.instance.get(BindingEngine);
+    instruction.attributes = {
+      ...instruction.attributes,
+      "active-tab-id": bindingEngine.createBindingExpression("activeTabId", "'0'")
+    };
+
+    node.append(headerTemplate, contentTemplate);
+    return true;
+  }
+
+  @bindable public activeTabId: string;
+  public showTab(tabId: string) { this.activeTabId = tabId; }
+}
+```
+
+The `processTabs` method used in `@processContent` may look overwhelming, but all it does is mostly pure DOM manipulation. The function takes four arguments, out of which `node` holds the DOM fragment for `<tabs>...</tabs>` used in `app.html`. And then in this function, we transforms the original DOM fragment to something like below.
 
 ```HTML 
 <tabs>
-  <div>
-    <button class="btn btn-link">Top Movies</button>
-    <button class="btn btn-link">Top TV Shows</button>
-    <button class="btn btn-link">Recently Added</button>
-  </div>
-  <tab header="Tab 1"></tab>
-  <tab header="Tab 2"></tab>
-  <tab header="Tab 3"></tab>
+  <template replace-part="header">
+    <button click.delegate="showTab('0')">Top Movies</button>
+    <button click.delegate="showTab('1')">Top TV Shows</button>
+    <button click.delegate="showTab('2')">Recently Added</button>
+  </template>
+  <template replace-part="content">
+    <div show.bind="activeTabId=='0'">...</div>
+    <div show.bind="activeTabId=='1'">...</div>
+    <div show.bind="activeTabId=='2'">...</div>
+  </template>
 </tabs>
 ```
+
+You must have noted that we have also used the some Aurelia syntaxes such as `click.delegate`, or `show.bind`. We have even used `instruction` to bind the `@bindable activeTabId` of `Tabs` class, by `createBindingExpression` using `BindingEngine`. This enables us to set `'0'` to `activeTabId` which in turn activates the first tab by default. However, we need to instruct Aurelia to process these instructions further which we do by `return`ing `true` at the end of the function. To keep the example simple, we have removed some non-crucial part of the code. However, you can see the result and source code below and play with it.
+
 [simple tab demo](https://codesandbox.io/s/r5v171o1wo?autoresize=1&hidenavigation=1&module=%2Fsrc%2FTabs.js&view=preview)
 
-<!-- TODO add tab content and click.delegate binding -->
-<!-- TODO show how to use custom element -->
+You maybe thinking that "all that is okay, but how the heck can I use my awesome custom controls??". You can definitely do that. In our example, we are packing all the child nodes of `tabs` directly to the respective content `div`. Therefore, you are absolutely free to use your awesome custom controls to compose the tab content. Let's see if we can use a custom element for the header? This might be good idea, as you start adding some styles to the header, it might start looking bulky and messy (as you might have seen in the code sandbox). Let's start with creating a custom element for the tab header.
+
+```HTML TabHeader.html
+<template>
+	<button class="btn btn-link" class.bind="isActive?'active':''" click.delegate="tabSelector()">
+    ${name}
+  </button>
+</template>
+```
+
+```JavaScript TabHeader.js
+import { bindable } from "aurelia-framework";
+
+export class TabHeader {
+  @bindable tabId;
+  @bindable isActive;
+  @bindable name;
+  @bindable tabSelector = id => {};
+}
+```
+
+```TypeScript TabHeader.ts [variant]
+import { bindable } from "aurelia-framework";
+
+export class TabHeader {
+  @bindable public tabId: string;
+  @bindable public isActive: boolean;
+  @bindable public name: string;
+  @bindable public tabSelector: (id:string) => void = id => {};
+}
+```
+
+This is a pretty simple and straight forward custom element with couple of `@bindable`s used to display and decorate the `button` in the view. There is a `@bindable` lambda/arrow function to select the tabs. We intend to bind this value from `Tabs` so that it retains the control over showing a particular tab (because you know we might want to compute the answer to life, the universe and everything there). To use this custom element in Tabs, we start by including that in `Tabs.html` and replacing the `button` in `processTabs` with `tab-header`.
+
+```HTML Tabs.html
+<template>
+  <require from="./TabHeader"></require>
+  ...
+</template>
+```
+
+```JavaScript Tabs.js
+function processTabs(compiler, resources, node, instruction) {
+  ...
+  for(let i = 0; i < tabs.length; i++) {
+    const tab = tabs[i];
+
+    // add header
+    const header = document.createElement("tab-header");
+    header.setAttribute("tab-id", `${i}`);
+    header.setAttribute("name", tab.getAttribute("header"));
+    header.setAttribute("is-active.bind", `activeTabId=='${i}'`);
+    header.setAttribute("tab-selector.bind", `showTab('${i}')`);
+    
+    ...
+  }
+  ...
+  return true;
+}
+...
+```
+
+```JavaScript Tabs.ts [variant]
+export class Tabs {
+  public static processTabs(_compiler, resources: ViewResources, node: HTMLElement, instruction: BehaviorInstruction) {
+    ...
+    for(let i = 0; i < tabs.length; i++) {
+      const tab = tabs[i];
+
+      // add header
+      const header = document.createElement("tab-header");
+      header.setAttribute("tab-id", `${i}`);
+      header.setAttribute("name", tab.getAttribute("header"));
+      header.setAttribute("is-active.bind", `activeTabId=='${i}'`);
+      header.setAttribute("tab-selector.bind", `showTab('${i}')`);
+      
+      ...
+    }
+    ...
+    return true;
+  }
+  ...
+}
+```
+
+You might expect this much to work. However, there is caveat. When we do the DOM transformation in `processContent`, we manipulate the DOM of the parent view, in this case that is `app.html`. As we have not `require`d the `tab-header` in `app.html`, it has no idea of how to process a `tab-header` when we create a `tab-header` element in `processContent`, as it has no prior knowledge of existence of `tab-header` custom element. A couple of naive solution includes `require`ing `TabHeader` in `app.html`, or registering that as a global resource. However, in both the cases, the `Tabs` control looses complete control over its view. Instead, we can register the additional resource (`tab-header`) in `processTabs` as follows.
+
+```JavaScript Tabs.js
+function processTabs(compiler, resources, node, instruction) {
+  ...
+
+  resources.registerElement("tab-header", instruction.type.viewFactory.resources.getElement("tab-header"));
+
+  for(let i = 0; i < tabs.length; i++) {
+    const tab = tabs[i];
+
+    // add header
+    const header = document.createElement("tab-header");
+    header.setAttribute("tab-id", `${i}`);
+    header.setAttribute("name", tab.getAttribute("header"));
+    header.setAttribute("is-active.bind", `activeTabId=='${i}'`);
+    header.setAttribute("tab-selector.bind", `showTab('${i}')`);
+    
+    ...
+  }
+  ...
+  return true;
+}
+...
+```
+
+```JavaScript Tabs.ts [variant]
+import { BehaviorInstruction, bindable, BindingEngine, Container, processContent, ViewResources } from "aurelia-framework";
+
+export class Tabs {
+  public static processTabs(_compiler, resources: ViewResources, node: HTMLElement, instruction: BehaviorInstruction) {
+    ...
+    resources.registerElement("tab-header", instruction.type.viewFactory.resources.getElement("tab-header"));
+
+    for(let i = 0; i < tabs.length; i++) {
+      const tab = tabs[i];
+
+      // add header
+      const header = document.createElement("tab-header");
+      header.setAttribute("tab-id", `${i}`);
+      header.setAttribute("name", tab.getAttribute("header"));
+      header.setAttribute("is-active.bind", `activeTabId=='${i}'`);
+      header.setAttribute("tab-selector.bind", `showTab('${i}')`);
+      
+      ...
+    }
+    ...
+    return true;
+  }
+  ...
+}
+```
+
+This registration works, because by the time Aurelia calls the `processContent` function, the view of the custom element is already compiled. Thus, at this point Aurelia knows which view resources are needed by custom element itself. In our case it knows that `Tabs` need `TabHeader`, as we `require`d that in `Tabs.html`. Therefore, the last thing to do is to register the `tab-header` element, so that `app` also knows about this. You can check out the complete code and the result in the embedded sandbox below. The lines of code in this version might be more than the simpler version with `button`, but now you know how to use your custom element in `processContent`.
+
+[simple tab demo](https://codesandbox.io/s/48lj5v3924?autoresize=1&hidenavigation=1&module=%2Fsrc%2FTabs.js&view=preview)
+
+*Psst psst: have you noted that you can register the control with a different name and use that while creating the element? So it is possible to alias your `tab-header` as `zaphod-beeblebrox`. Fancy that!*
+
+Finally, if you have ideas of better usage, we will happily consider a PR.


### PR DESCRIPTION
Submitting documentation on `@processContent` for review. The suggestion coined from [the discussion on discourse](https://discourse.aurelia.io/t/better-know-a-framework-18-what-processcontent-is-and-what-it-is-used-for/1785).

@EisenbergEffect @bigopon Hope the details provided is easy to understand. However, please feel free to suggest/make edits.