### PR TITLE
docs(cli): cookbook entry for TypeORM in frontend

### DIFF
--- a/current/en-us/11. cli/4. cli-bundler/4. cook-book.md
+++ b/current/en-us/11. cli/4. cli-bundler/4. cook-book.md
@@ -304,3 +304,49 @@ export class App {
   </div>
 </template>
 ```
+
+## TypeORM with shimmed decorators
+
+When using TypeORM in the frontend, you'll most likely experience issues due to leveraged node dependencies not available within the browser. To circumvent this import a wrapper instead. Most likely you're also going to share entities with your server part, so do not forget to add the `paths` entry in `aurelia.json` as well:
+
+`npm install typeorm` or `yarn add typeorm`
+
+```JSON aurelia_project/aurelia.json
+"bundles": [
+  // ...
+  {
+    "name": "vendor-bundle.js",
+    "prepend": [ /* ... */ ],
+    "dependencies": [
+      // ...
+      {
+        "name": "typeorm",
+        "path": "../node_modules/typeorm",
+        "main": "typeorm-model-shim"
+      }
+    ]
+  }
+],
+"paths": {
+  ...
+  "entities": "../../server/src/entity"
+}
+```
+
+> This example expects the aurelia app and the node backend folder structure to located next to each other in `frontend` and respecitvely `server`, with `server` having subfolders `src/entity` containing all your entity files.
+
+If you're using TypeScript for your project make sure to add an additional path mapping to your `tsconfig.json` as well:
+
+```JSON aurelia_project/aurelia.json
+{
+  ...
+  "compilerOptions": {
+    ...
+    "paths": {
+      "entities/*": ["../../server/src/entity/*"]
+    },
+    "baseUrl": "src"
+  }
+  ...
+}
+```


### PR DESCRIPTION
instructions on how to load the frontend wrapper for TypeORM and how to configure paths to point to your server entity files