### PR TITLE
chore: remove all self-closing on HTML snippets

### DIFF
--- a/current/en-us/5. templating/4. custom-elements.md
+++ b/current/en-us/5. templating/4. custom-elements.md
@@ -70,6 +70,9 @@ The following example shows an Aurelia view utilizing two-way databinding to an 
 
 Custom elements are not allowed to be self-closing. This means that `<secret-message />` will not work. When using a custom element, you must provide a closing tag as shown in `app.html` below.
 
+> Info
+> This is not a limitation of Aurelia. It is HTML5 who doesn't support self-closing syntax. Self-closing is a XML syntax, not HTML5. To be clear, you can use self-closing in SVG when it's embedded inside HTML page, because SVG is actually XML. When browser parses an embedded SVG inside HTML page, it uses XML parser to parse the SVG part.
+
 ```JavaScript secret-message.js
 export class SecretMessageCustomElement {
   secretMessage = 'Be sure to drink your Ovaltine!';
@@ -274,7 +277,7 @@ Full name is: "${fullName}"
 
 And now after either `firstName` or `lastName` has changed, `fullName` is recomputed automatically and is ready to be used in other parts of the view.
 
-Additionally, if there is a need to react to changes on both `fullName`, we can specify a special attribute `to-binding-context` on the `<let/>` element to notify bindings to assign the value to the binding context, which is your view model, instead of override context, which is your view.
+Additionally, if there is a need to react to changes on both `fullName`, we can specify a special attribute `to-binding-context` on the `<let></let>` element to notify bindings to assign the value to the binding context, which is your view model, instead of override context, which is your view.
 
 ```HTML Declarative Computed Context View
 <let to-binding-context full-name="${firstName} ${lastName}"></let>
@@ -406,7 +409,7 @@ A naive approach would be to use something like this:
 However, with this code Aurelia will perform string interpolation for `\${message}`, and depending on whether or not the view-model has a `message` property, the app will display the value of `message` or nothing. But that is not what was intended. To show such code fragments, we can create a no-op custom element to wrap them.
 
 ```TypeScript CodeFragment.ts
-// reference: https://stackoverflow.com/a/50066210/2270340 
+// reference: https://stackoverflow.com/a/50066210/2270340
 import { noView, processContent } from "aurelia-framework";
 
 @noView()
@@ -619,7 +622,7 @@ export class Tabs {
 
 The `processTabs` method used in `@processContent` may look overwhelming, but it's mostly pure DOM manipulation. The function takes four arguments, out of which `node` holds the DOM fragment for `<tabs>...</tabs>` used in `app.html`. And then in this function, we transforms the original DOM fragment to something like below.
 
-```HTML 
+```HTML
 <tabs>
   <template replace-part="header">
     <button click.delegate="showTab('0')">Top Movies</button>
@@ -690,7 +693,7 @@ function processTabs(compiler, resources, node, instruction) {
     header.setAttribute("name", tab.getAttribute("header"));
     header.setAttribute("is-active.bind", `activeTabId=='${i}'`);
     header.setAttribute("tab-selector.bind", `showTab('${i}')`);
-    
+
     ...
   }
   ...
@@ -711,7 +714,7 @@ export class Tabs {
       header.setAttribute("name", tab.getAttribute("header"));
       header.setAttribute("is-active.bind", `activeTabId=='${i}'`);
       header.setAttribute("tab-selector.bind", `showTab('${i}')`);
-      
+
       ...
     }
     ...
@@ -738,7 +741,7 @@ function processTabs(compiler, resources, node, instruction) {
     header.setAttribute("name", tab.getAttribute("header"));
     header.setAttribute("is-active.bind", `activeTabId=='${i}'`);
     header.setAttribute("tab-selector.bind", `showTab('${i}')`);
-    
+
     ...
   }
   ...
@@ -763,7 +766,7 @@ export class Tabs {
       header.setAttribute("name", tab.getAttribute("header"));
       header.setAttribute("is-active.bind", `activeTabId=='${i}'`);
       header.setAttribute("tab-selector.bind", `showTab('${i}')`);
-      
+
       ...
     }
     ...

--- a/current/en-us/7. plugins/3. validation.md
+++ b/current/en-us/7. plugins/3. validation.md
@@ -55,7 +55,7 @@ ValidationRules
 Once you've targetted a property using `ensure` you can define the property's display name using `.displayName(name: string|ValidationDisplayNameAccessor)`. Display names are used in validation messages. Specifying a display name is optional. If you do not explicitly set the display name the validation engine will attempt to compute the display name for you by splitting the property name on upper-case letters. A `firstName` property's display name would be `First Name`.
 
 ```JavaScript displayName
-ValidationRules      
+ValidationRules
   .ensure('ssn').displayName('SSN')...
 ```
 
@@ -88,7 +88,7 @@ All rules have a standard message that can be overriden on a case-by-case basis 
 Here's an example:
 
 ```JavaScript withMessage
-ValidationRules      
+ValidationRules
   .ensure('ssn').displayName('SSN')
     .required().withMessage(`\${$displayName} cannot be blank.`);
     .matches(/\d{3}-\d{2}-\d{4}/).withMessage(`"\${$value}" is not a valid \${$displayName}.`);
@@ -307,7 +307,7 @@ Invoking the validate method with no arguments will validate all bindings and ob
 controller.validate();
 controller.validate({ object: person });
 controller.validate({ object: person, rules: myRules });
-controller.validate({ object: person, propertyName: 'firstName' });    
+controller.validate({ object: person, propertyName: 'firstName' });
 controller.validate({ object: person, propertyName: 'firstName', rules: myRules });
 
 controller.validate()
@@ -377,7 +377,7 @@ The `validate` binding behavior enables quick and easy validation for two-way da
 
 <input type="text" value.bind="person['firstName'] | upperCase & validate">
 
-<input type="text" value.bind="currentEntity[p] & debounce & validate">    
+<input type="text" value.bind="currentEntity[p] & debounce & validate">
 ```
 
 `validate` accepts a couple of optional arguments enabling you to explicitly specify the rules and controller instance:
@@ -758,21 +758,21 @@ In your view you need to take care to associate each input with the correct vali
   <form validation-errors="errors.bind: pizzaErrors; controller.bind: pizzaValidationController"
         submit.delegate="orderPizza()">
     <label for="pizza">Choose a pizza:</label>
-    <input id="pizza" value.bind="pizza & validateManually:pizzaValidationController"/>
+    <input id="pizza" value.bind="pizza & validateManually:pizzaValidationController">
     <span class="help-block" repeat.for="errorInfo of pizzaErrors">
       ${errorInfo.error.message}
     </span>
-    <input type="submit" value="Order pizza!"/>
+    <input type="submit" value="Order pizza!">
   </form>
 
   <form validation-errors="errors.bind: pastaErrors; controller.bind: pastaValidationController"
         submit.delegate="orderPasta()">
     <label for="pasta">Choose a pasta:</label>
-    <input id="pasta" value.bind="pasta & validateManually:pastaValidationController"/>
+    <input id="pasta" value.bind="pasta & validateManually:pastaValidationController">
     <span class="help-block" repeat.for="errorInfo of pastaErrors">
       ${errorInfo.error.message}
     </span>
-    <input type="submit" value="Order pasta!"/>
+    <input type="submit" value="Order pasta!">
   </form>
 </template>
 ```
@@ -851,7 +851,7 @@ export function configure(aurelia) {
     return i18n.tr(propertyName);
   };
 
-  ...      
+  ...
   ...
 }
 ```
@@ -863,11 +863,11 @@ Once you've overriden the necessary methods in `ValidationMessageProvider` you'r
 ```HTML I18N View
 <template>
   <form>
-    <label>${'firstName' & t}: <br />
-      <input type="text" value.bind="firstName & validate" />
+    <label>${'firstName' & t}: <br>
+      <input type="text" value.bind="firstName & validate">
     </label>
-    <label>${'lastName' & t}: <br />
-      <input type="text" value.bind="lastName & validate" />
+    <label>${'lastName' & t}: <br>
+      <input type="text" value.bind="lastName & validate">
     </label>
     <button click.delegate="submit()">${'submit' & t}</button>
   </form>
@@ -882,7 +882,7 @@ Once you've overriden the necessary methods in `ValidationMessageProvider` you'r
   </div>
 
   <button click.trigger="switchLanguage()">${'switchLanguage' & t}</button>
-<template>   
+<template>
 ```
 
 Here's the view model:
@@ -939,7 +939,7 @@ export class App {
 Last but not least, create translation files that include translations for each propertyName and each validation message key. Below are the German and English files for the example above. Notice the `errorMessages` section has the translation for the `required` rule. In practice, you would need translations for each rule that you use. Take a look at the [`validationMessages` export](https://github.com/aurelia/validation/blob/master/src/implementation/validation-messages.ts) for the full list.
 
 ```JSON Translation files
-// file: locales/de/translation.json    
+// file: locales/de/translation.json
 {
   "firstName": "Vorname",
   "lastName": "Nachname",

--- a/current/en-us/7. plugins/4. i18n.md
+++ b/current/en-us/7. plugins/4. i18n.md
@@ -561,7 +561,7 @@ Nested keys may also be referenced and will be properly translated:
 Images can be translated as well, for when a different image needs to be displayed in another language.
 
 ```HTML
-<img t="home.image" />
+<img t="home.image">
 ```
 
 The plugin will automatically change the `src` attribute of the image when the locale changes.
@@ -569,7 +569,7 @@ The plugin will automatically change the `src` attribute of the image when the l
 You may specify a default value for images as well. In order to do so just define an attribute called `data-src` with the default value.
 
 ```HTML
-<img data-src="path/to/image.jpg" t="home.image" />
+<img data-src="path/to/image.jpg" t="home.image">
 ```
 
 This will be picked up by the CLI when translations are extracted from the source files. (see the section on [CLI Integration](#cli-integration))
@@ -617,24 +617,24 @@ You will find below a few examples of the available [i18next features](http://i1
         <h3>ValueConverter Examples</h3>
         <ul class="list-group">
           <li class="list-group-item">
-            Translation with Variables: <br />
+            Translation with Variables: <br>
             ${ 'score' | t: {'score': userScore}}
           </li>
 
           <li class="list-group-item">
-            Translation singular: <br />
+            Translation singular: <br>
             ${ 'lives' | t: { 'count': 1 } }
           </li>
 
           <li class="list-group-item">
-            Translation plural: <br />
+            Translation plural: <br>
             ${ 'lives' | t: { 'count': 2 } }
           </li>
 
           <li class="list-group-item">
-            Translation without/with context: <br />
-            ${ 'friend' | t } <br />
-            ${ 'friend' | t: { context: 'male' } } <br />
+            Translation without/with context: <br>
+            ${ 'friend' | t } <br>
+            ${ 'friend' | t: { context: 'male' } } <br>
             ${ 'friend' | t: { context: 'female' } }
           </li>
         </ul>
@@ -650,7 +650,7 @@ The TValueConverter is pretty useful if you prefer a declarative way to enhance 
 
 ```HTML TBindingBehavior Example
 <li class="list-group-item">
-  Translation with Variables: <br />
+  Translation with Variables: <br>
   ${ 'score' & t: {'score': userScore}}
 </li>
 ```
@@ -1050,7 +1050,7 @@ export function configure(aurelia) {
         debug      : false,
       });
     });
-  
+
   aurelia.start().then(() => aurelia.setRoot(PLATFORM.moduleName('app')));
 }
 ```

--- a/current/en-us/7. plugins/6. animation.md
+++ b/current/en-us/7. plugins/6. animation.md
@@ -224,7 +224,7 @@ As an example example, we may have multiple `li` elements rendering in a repeate
     repeat.for="todo of todos"
     class="au-animate animate-fade-in animate-fade-out"
   >
-    <input type="checkbox" checked.bind="todo.done" />
+    <input type="checkbox" checked.bind="todo.done">
     <span css="text-decoration: ${todo.done ? 'line-through' : 'none'}">
       ${todo.description}
     </span>

--- a/current/en-us/7. plugins/7. virtualization.md
+++ b/current/en-us/7. plugins/7. virtualization.md
@@ -113,7 +113,7 @@ The UI Virtualization plugin allows you to virtually scroll lists comprised of m
 ```Javascript app.js
 export class App {
     items = ['Foo', 'Bar', 'Baz'];
-    
+
     getMore(topIndex, isAtBottom, isAtTop) {
         for(let i = 0; i < 100; ++i) {
             this.items.push('item' + i);
@@ -135,7 +135,7 @@ Similarly, the `infinite-scroll-next` attribute also supports using an expressio
 ```Javascript app.js
 export class App {
     items = ['Foo', 'Bar', 'Baz'];
-    
+
     getMore(scrollContext) {
         for(let i = 0; i < 100; ++i) {
             this.items.push('item' + i);
@@ -148,8 +148,8 @@ The infinite-scroll-next attribute can accept a function, a promise, or a functi
 
 ## Caveats
 
-1. `<template/>` is not supported as a root element of a virtual repeat template, because virtualization requires item heights to be calculatable. With `<tempate/>`, there is no easy and performant way to acquire this value.
-2. Similar to (1), other template controllers cannot be used in conjunction with 1virtual-repeat1, unlike repeat i.e: built-in template controllers: `with`, `if`, `replaceable` cannot be used with `virtual-repeat`. You can easily work around this constraint by nesting other template controllers inside the repeated element, with `<template/>` element, for example:
+1. `<template></template>` is not supported as a root element of a virtual repeat template, because virtualization requires item heights to be calculatable. With `<template></template>`, there is no easy and performant way to acquire this value.
+2. Similar to (1), other template controllers cannot be used in conjunction with 1virtual-repeat1, unlike repeat i.e: built-in template controllers: `with`, `if`, `replaceable` cannot be used with `virtual-repeat`. You can easily work around this constraint by nesting other template controllers inside the repeated element, with `<template></template>` element, for example:
 
 ```Html app.html
 <template>

--- a/current/en-us/8. integration/1. polymer.md
+++ b/current/en-us/8. integration/1. polymer.md
@@ -129,7 +129,7 @@ Given the imports above, this shows how to implement a basic layout in `app.html
       <paper-toolbar class="paper-header">
         <paper-icon-button icon="menu" tabindex="1" paper-drawer-toggle></paper-icon-button>
         <div class="title">${router.title}</div>
-        <span if.bind="router.isNavigating"><iron-icon icon="autorenew"/></span>
+        <span if.bind="router.isNavigating"><iron-icon icon="autorenew"></iron-icon></span>
       </paper-toolbar>
       <div>
         <router-view></router-view>


### PR DESCRIPTION
Because self-closing is not supported in HTML5. A note is added in the document.

@EisenbergEffect this replaces aurelia/validation#505