### PR TITLE
docs(current): change to PLATFORM.moduleName('aurelia-validation')

### DIFF
--- a/current/en-us/7. plugins/3. validation.md
+++ b/current/en-us/7. plugins/3. validation.md
@@ -8,7 +8,7 @@ author: Jeremy Danyow (http://danyow.net)
 
 This article covers the basics of validation with Aurelia's validation plugin. You'll learn how to add validation to your applications using a fluent rule API and minimal changes to your templates.
 
-To get started you'll need to install `aurelia-validation` using `jspm install aurelia-validation` or `npm install aurelia-validation --save`. Afterwards, add `.plugin('aurelia-validation')` to the configuration in your `main.js` to ensure the plugin is loaded at application startup.
+To get started you'll need to install `aurelia-validation` using `jspm install aurelia-validation` or `npm install aurelia-validation --save`. Afterwards, add `.plugin(PLATFORM.moduleName('aurelia-validation'))` to the configuration in your `main.js` to ensure the plugin is loaded at application startup.
 
 If you're using the `aurelia-cli`, add the following configuration to your `aurelia.json` after you've installed the package with npm.
 
@@ -814,7 +814,7 @@ import {BreezeValidator} from './breeze-validator';
 export function configure(aurelia) {
   aurelia.use
     .standardConfiguration()
-    .plugin('aurelia-validation', config => config.customValidator(BreezeValidator))
+    .plugin(PLATFORM.moduleName('aurelia-validation'), config => config.customValidator(BreezeValidator))
     ...
 
   ...


### PR DESCRIPTION
The documentation now indicates the correct way to import the Validation plugin with webpack that is using `PLATFORM.moduleName('aurelia-validation')` instead of `.plugin('aurelia-validation')`.

This commit closes the issue #522.