### PR TITLE
doc(store): remove outdated instruction for aurelia-cli

### DIFF
--- a/current/en-us/7. plugins/2. store.md
+++ b/current/en-us/7. plugins/2. store.md
@@ -50,37 +50,9 @@ yarn add aurelia-store
 > Info
 > If you're not using RxJS at all so far it is recommended to run `npm install rxjs` which should install the latest available rxjs (currently 6.x.x) version as a project dependency.
 
-If your app is based on the Aurelia CLI and the build is based on RequireJS or SystemJS, you can setup the plugin using the following automatic dependency import:
-
-```Shell
-au import aurelia-store
-```
-
-alternatively, you can manually add these dependencies to your vendor bundle:
-
-```JSON
-...
-"dependencies": [
-  {
-    "name": "aurelia-store",
-    "path": "../node_modules/aurelia-store/dist/amd",
-    "main": "aurelia-store"
-  },
-  {
-    "name": "rxjs",
-    "main": "./index.js",
-    "path": "../node_modules/rxjs"
-  },
-  {
-    "name": "rxjs/operators",
-    "main": "./index.js",
-    "path": "../node_modules/rxjs/operators"
-  }
-]
-```
 
 > Info
-> With the recent release of RxJS v.6, which this plugin depends on, quite a lot has changed. There are new ways to import dependencies and ways to keep compatibility with previous API versions. Take a look at the [following upgrade instructions](https://github.com/ReactiveX/rxjs/blob/master/docs_app/content/guide/v6/migration.md) for further details. In case you're using a classic Require.js based Aurelia CLI project setup, make sure to [configure rxjs-compat](https://www.npmjs.com/package/rxjs-compat) in aurelia.json as a dependency and use it as the main include file. If you do on the other hand already use the newest APIs you'll have to adjust your `aurelia.json` or do a fresh new `au import aurelia-store` to get the rxjs dependencies properly auto-setup.
+> With the recent release of RxJS v.6, which this plugin depends on, quite a lot has changed. There are new ways to import dependencies and ways to keep compatibility with previous API versions. Take a look at the [following upgrade instructions](https://github.com/ReactiveX/rxjs/blob/master/docs_app/content/guide/v6/migration.md) for further details.
 
 ## Bring your own polyfills (BYOP)
 This plugin depends on the [Object.entries feature](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries#Polyfill) which is not available in Internet Explorer out of the box.


### PR DESCRIPTION
@zewa666 can you have a look? I remove the mention of rxjs-compat because the rxjs migration guide  covered that, but I have no idea how to use rxjs-compat even after reading the migration guide.

The guide mentioned `npm install rxjs@6 rxjs-compat@6 --save` but has no code to `import 'rxjs-compat';`. How does it work?
