### PR TITLE
docs(current): change to PLATFORM.moduleName('app') and to 'aurelia-bootstrapper'

### DIFF
--- a/current/en-us/3. fundamentals/1. app-configuration-and-startup.md
+++ b/current/en-us/3. fundamentals/1. app-configuration-and-startup.md
@@ -212,7 +212,7 @@ So far, we've been bootstrapping our app declaratively by using the `aurelia-app
 In case you use Webpack, you can replace the `aurelia-bootstrapper-webpack` package with the `./src/main` entry file in the `aurelia-bootstrapper` bundle defined inside of `webpack.config.js`, and call the bootstrapper manually:
 
 ```JavaScript Manual Bootstrapping with Webpack
-import {bootstrap} from 'aurelia-bootstrapper-webpack';
+import {bootstrap} from 'aurelia-bootstrapper';
 
 bootstrap(async aurelia => {
   aurelia.use
@@ -220,12 +220,12 @@ bootstrap(async aurelia => {
     .developmentLogging();
 
   await aurelia.start();
-  aurelia.setRoot('app', document.body);
+  aurelia.setRoot(PLATFORM.moduleName('app'), document.body);
 });
 ```
 ```TypeScript Manual Bootstrapping with Webpack [variant]
 import {Aurelia} from 'aurelia-framework';
-import {bootstrap} from 'aurelia-bootstrapper-webpack';
+import {bootstrap} from 'aurelia-bootstrapper';
 
 bootstrap(async (aurelia: Aurelia) => {
   aurelia.use
@@ -233,7 +233,7 @@ bootstrap(async (aurelia: Aurelia) => {
     .developmentLogging();
 
   await aurelia.start();
-  aurelia.setRoot('app', document.body);
+  aurelia.setRoot(PLATFORM.moduleName('app'), document.body);
 });
 ```
 


### PR DESCRIPTION
The documentation now indicates the correct code for manual bootstrapping of an aurelia application using Webpack.
* changed the import from `import {bootstrap} from 'aurelia-bootstrapper-webpack';` to `import {bootstrap} from 'aurelia-bootstrapper';`
* using `PLATFORM.moduleName('app')` as `.setRoot()` argument.

This commit closes the issue #417 .