### PR TITLE
Reword HTML Behavior Lifecycle info to be same as fundamentals/creating-components#the-component-lifecycle

### DIFF
--- a/current/en-us/5. templating/2. html-behaviors.md
+++ b/current/en-us/5. templating/2. html-behaviors.md
@@ -328,8 +328,8 @@ All HTML Behaviors have a well defined lifecycle. Using this lifecycle, you can 
 5. `detached()` - At some point in the future, the component may be removed from the DOM. If/When this happens, and if the view-model has a `detached` callback, this is when it will be invoked.
 6. `unbind()` - After a component is detached, it's usually unbound. If your view-model has the `unbind` callback, it will be invoked during this process.
 
-> Info: Bind callback stops initial "Changed" callbacks
-> It should be noted that when the view-model has implemented the `bind` callback, the databinding framework will not invoke the changed handlers for the view-model's bindable properties until the "next" time those properties are updated. If you need to perform specific post-processing on your bindable properties, when implementing the `bind` callback, you should do so manually within the callback itself. For example, if you have a bindable property `foo`, implement the `fooChanged` callback, and you want `fooChanged` to be called on initial binding, then you will need to call it from within your `bind()` callback.
+> Info
+> It is important to note that if you implement the `bind` callback function, then the property changed callbacks for any `bindable` properties will not be called when the property value is initially set. The changed callback will be called for any subsequent time the bound value changes.
 
 Tapping into a lifecycle event is as simple as implementing any of the above methods on the behavior's view-model class. Here's an example of a custom attribute that uses the attached and detached callbacks, something common when wrapping jQuery plugins:
 


### PR DESCRIPTION
See fundamentals/creating-components#the-component-lifecycle which contains a duplicate of this lifecycle.

Except fundamentals/creating-components#the-component-lifecycle info box is clear and concise.

This page's version should be the same as the extra information doesn't add anything and also waters down the information contained with too much detail.