### PR TITLE
Vm to viewmodel

### DIFF
--- a/current/en-us/5. templating/3. custom-attributes.md
+++ b/current/en-us/5. templating/3. custom-attributes.md
@@ -150,7 +150,7 @@ When the user updates the value of the `color` property via the textbox, Aurelia
 
 ## Options Binding
 
-Options binding provides a custom attribute the ability to have multiple bindable properties. Each bindable property must be specified using the `bindable` decorator. The attribute view-model may implement an optional `\${propertyName}Changed(newValue, oldValue)` callback function for each bindable property. When binding to these options, separate each option with a semicolon and supply a binding command or literal value as in the example below. It is important to note that bindable properties are converted to dash-case when used in the DOM, while the VM property they are bound to are kept with their original casing.
+Options binding provides a custom attribute the ability to have multiple bindable properties. Each bindable property must be specified using the `bindable` decorator. The attribute view-model may implement an optional `\${propertyName}Changed(newValue, oldValue)` callback function for each bindable property. When binding to these options, separate each option with a semicolon and supply a binding command or literal value as in the example below. It is important to note that bindable properties are converted to dash-case when used in the DOM, while the view-model property they are bound to are kept with their original casing.
 
 ```JavaScript square.js
 import {bindable, inject} from 'aurelia-framework';

--- a/current/en-us/5. templating/3. custom-attributes.md
+++ b/current/en-us/5. templating/3. custom-attributes.md
@@ -62,7 +62,7 @@ export class MyClass {
 
 ## Single Value Binding
 
-Aurelia custom attributes support three different types of binding: single value binding, options binding, and dynamic options binding. The simplest of the three binding types is single value binding. Aurelia will automatically set the `value` property on the attribute's view-model. Note that this property is not set until databinding is complete. This means the `value` property will not be set in the custom attribute's constructor or in its `created` lifecycle event. It is available in the `bind` and later lifecycle events.
+Aurelia custom attributes support three different types of binding: single value binding, options binding, and dynamic options binding. The simplest of the three binding types is single value binding. Aurelia will automatically set the `value` property on the attribute's ViewModel. Note that this property is not set until databinding is complete. This means the `value` property will not be set in the custom attribute's constructor or in its `created` lifecycle event. It is available in the `bind` and later lifecycle events.
 
 ```JavaScript square.js
 export class SquareCustomAttribute {
@@ -103,7 +103,7 @@ export class SquareCustomAttribute {
 </template>
 ```
 
-Note that in the above code sample, the color of the square will not be updated, even if the bound value is changed. This is because the attribute is not notified when the `value` property changes. Aurelia can notify a custom attribute when its value has changed, via the `valueChanged(newValue, oldValue)` callback function. The `valueChanged` callback function, if implemented on the view-model, will be called whenever the attribute's value changes. This function has two optional parameters, `newValue` and `oldValue`. These parameters will be set to the new value of the attribute and old value of the attribute, respectively. The `value` property is still set by Aurelia even if the `valueChanged` function is implemented. Note that if you implement both the `bind` and `valueChanged` callbacks, only `bind` will be called when the value is initially bound. If you implement only the `valueChanged` function, then it will be called when the value is initially bound.
+Note that in the above code sample, the color of the square will not be updated, even if the bound value is changed. This is because the attribute is not notified when the `value` property changes. Aurelia can notify a custom attribute when its value has changed, via the `valueChanged(newValue, oldValue)` callback function. The `valueChanged` callback function, if implemented on the ViewModel, will be called whenever the attribute's value changes. This function has two optional parameters, `newValue` and `oldValue`. These parameters will be set to the new value of the attribute and old value of the attribute, respectively. The `value` property is still set by Aurelia even if the `valueChanged` function is implemented. Note that if you implement both the `bind` and `valueChanged` callbacks, only `bind` will be called when the value is initially bound. If you implement only the `valueChanged` function, then it will be called when the value is initially bound.
 
 ```JavaScript square.js
 export class SquareCustomAttribute {
@@ -150,7 +150,7 @@ When the user updates the value of the `color` property via the textbox, Aurelia
 
 ## Options Binding
 
-Options binding provides a custom attribute the ability to have multiple bindable properties. Each bindable property must be specified using the `bindable` decorator. The attribute view-model may implement an optional `\${propertyName}Changed(newValue, oldValue)` callback function for each bindable property. When binding to these options, separate each option with a semicolon and supply a binding command or literal value as in the example below. It is important to note that bindable properties are converted to dash-case when used in the DOM, while the view-model property they are bound to are kept with their original casing.
+Options binding provides a custom attribute the ability to have multiple bindable properties. Each bindable property must be specified using the `bindable` decorator. The attribute ViewModel may implement an optional `\${propertyName}Changed(newValue, oldValue)` callback function for each bindable property. When binding to these options, separate each option with a semicolon and supply a binding command or literal value as in the example below. It is important to note that bindable properties are converted to dash-case when used in the DOM, while the ViewModel property they are bound to are kept with their original casing.
 
 ```JavaScript square.js
 import {bindable, inject} from 'aurelia-framework';
@@ -254,7 +254,7 @@ Or if you don't care about binding, then this:
 
 ## Dynamic Options Binding
 
-Utilizing dynamic options, a custom attribute may deal with bindable properties where the name of the property is not known when creating the attribute. Simply decorate the attribute's view-model with the `dynamicOptions` decorator and implement the `propertyChanged(name, newValue, oldValue)` callback function. Aurelia will provide the name of the option that has changed along with new and old values for the option. Binding to a dynamic options attribute works exactly the same as binding to an options attribute in the DOM.
+Utilizing dynamic options, a custom attribute may deal with bindable properties where the name of the property is not known when creating the attribute. Simply decorate the attribute's ViewModel with the `dynamicOptions` decorator and implement the `propertyChanged(name, newValue, oldValue)` callback function. Aurelia will provide the name of the option that has changed along with new and old values for the option. Binding to a dynamic options attribute works exactly the same as binding to an options attribute in the DOM.
 
 ```JavaScript square.js
 import {dynamicOptions, inject} from 'aurelia-framework';

--- a/current/en-us/7. plugins/2. store.md
+++ b/current/en-us/7. plugins/2. store.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: Managing App State
 description: Using the Aurelia Store plugin for predictable state management.
 author: Vildan Softic (http://github.com/zewa666)

--- a/current/en-us/7. plugins/2. store.md
+++ b/current/en-us/7. plugins/2. store.md
@@ -1,4 +1,4 @@
----
+﻿---
 name: Managing App State
 description: Using the Aurelia Store plugin for predictable state management.
 author: Vildan Softic (http://github.com/zewa666)
@@ -1021,7 +1021,7 @@ The result will be that a new state is emitted and your subscriptions will recei
 ## Two-way binding and state management
 Two-way binding definitely has its merits when it comes to easily develop applications. By having Aurelia take care of synchronizing of the View and ViewModel a lot of work gets done for free.
 This behavior though becomes troublesome when working with a central state management. Remember, the primary vision is to do state modifications only via dispatching actions. This way we guarantee a single source of truth and no side-effects.
-Yet exactly the later is what a two-way binding introduces if you bind your view-model directly to state objects. So instead of two-way binding to state objects you should:
+Yet exactly the later is what a two-way binding introduces if you bind your ViewModel directly to state objects. So instead of two-way binding to state objects you should:
 
 * Create a new property, reflecting the state part you'd like to modify and bind to that.
 * When changes are made, persist the changes by dispatching an action which uses the binding models values

--- a/current/en-us/7. plugins/2. store.md
+++ b/current/en-us/7. plugins/2. store.md
@@ -1021,7 +1021,7 @@ The result will be that a new state is emitted and your subscriptions will recei
 ## Two-way binding and state management
 Two-way binding definitely has its merits when it comes to easily develop applications. By having Aurelia take care of synchronizing of the View and ViewModel a lot of work gets done for free.
 This behavior though becomes troublesome when working with a central state management. Remember, the primary vision is to do state modifications only via dispatching actions. This way we guarantee a single source of truth and no side-effects.
-Yet exactly the later is what a two-way binding introduces if you bind your VM directly to state objects. So instead of two-way binding to state objects you should:
+Yet exactly the later is what a two-way binding introduces if you bind your view-model directly to state objects. So instead of two-way binding to state objects you should:
 
 * Create a new property, reflecting the state part you'd like to modify and bind to that.
 * When changes are made, persist the changes by dispatching an action which uses the binding models values

--- a/current/en-us/7. plugins/4. i18n.md
+++ b/current/en-us/7. plugins/4. i18n.md
@@ -1,4 +1,4 @@
----
+﻿---
 name: I18N
 description: Getting Started with I18N in your Aurelia App.
 author: Vildan Softic (http://pragmatic-coder.net)
@@ -333,7 +333,7 @@ In order to change the active language you'd have to call the function `setLocal
 ```JavaScript Setting the active locale with setLocale
 import {I18N} from 'aurelia-i18n';
 
-export class MyDemoVM {
+export class MyDemoViewModel {
   static inject = [I18N];
   constructor(i18n) {
     this.i18n = i18n;
@@ -354,7 +354,7 @@ To get the active locale you'd go with `getLocale()`:
 ```JavaScript Getting the active locale using getLocale
 import {I18N} from 'aurelia-i18n';
 
-export class MyDemoVM {
+export class MyDemoViewModel {
   static inject = [I18N];
   constructor(i18n) {
     this.i18n = i18n;
@@ -371,7 +371,7 @@ Translating stuff via code works by using the method `tr`. You pass in the `key`
 ```JavaScript Translating using the i18n.tr function
 import {I18N} from 'aurelia-i18n';
 
-export class MyDemoVM {
+export class MyDemoViewModel {
   static inject = [I18N];
   constructor(i18n) {
     this.i18n = i18n;
@@ -572,7 +572,7 @@ Also note that for whatever attribute you registered, the corresponding \*-param
 
 ```JavaScript
 // ViewModel
-class MyVM {
+class MyViewModel {
   params = { content: 'ABC' }
 
   [...]
@@ -698,7 +698,7 @@ Below is an example how to access the NumberFormat via code:
 ```JavaScript Number formatting via Code
 import {I18N} from 'aurelia-i18n';
 
-export class MyDemoVM {
+export class MyDemoViewModel {
   static inject = [I18N];
   constructor(i18n) {
     this.i18n = i18n;
@@ -748,7 +748,7 @@ A more declarative way is to use the `nf` ValueConverter from within your HTML m
 ```
 
 > Info
-> If you provide the active locale as a bound VM property, the ValueConverter will be re-evaluated as soon as the property value changes, resulting in automatic re-formatting of your number.
+> If you provide the active locale as a bound ViewModel property, the ValueConverter will be re-evaluated as soon as the property value changes, resulting in automatic re-formatting of your number.
 
 
 ### Formatting dates via code
@@ -759,7 +759,7 @@ Below you'll find an example how to use those via code:
 ```JavaScript Formatting Dates via Code
 import {I18N} from 'aurelia-i18n';
 
-export class MyDemoVM {
+export class MyDemoViewModel {
   static inject = [I18N];
   constructor(i18n) {
     this.i18n = i18n;
@@ -794,7 +794,7 @@ export class MyDemoVM {
 
 ### Formatting dates with DfValueConverter
 
-A more declarative way is to use the `df` ValueConverter from within your HTML markup. It essentially works the same way as the code version. Take a look at the following example, which defines a VM property myDate:
+A more declarative way is to use the `df` ValueConverter from within your HTML markup. It essentially works the same way as the code version. Take a look at the following example, which defines a ViewModel property myDate:
 
 ```HTML Declarative formatting of dates with the DfValueConverter
 <div class="col-md-3">
@@ -824,7 +824,7 @@ To use it via code get hold of the service via injection and call the method as 
 ```JavaScript Rendering relative time via Code
 import {RelativeTime} from 'aurelia-i18n';
 
-export class MyDemoVM {
+export class MyDemoViewModel {
   static inject = [RelativeTime];
   constructor(relativeTime) {
     this.rt = relativeTime;


### PR DESCRIPTION
I originally sent one through change VM to view-model.
view-model is used 37 times across documentation, while ViewModel is used 13 times.
Yet ViewModel is a better choice as that is what outside documentation refers to in `Model-View-ViewModel` and searching in the repository for view-model will not find code samples.
Unifying to ViewModel makes more sense.