### PR TITLE
Fix incorrect element name in composed visual tree for fallback-content.

### DIFF
--- a/current/en-us/5. templating/5. content-projection.md
+++ b/current/en-us/5. templating/5. content-projection.md
@@ -110,7 +110,7 @@ A nice feature of slots is that they can have fallback content. If nothing gets 
 ```
 
 ```HTML The Composed Visual Tree
-<named-slot>
+<fallback-content>
   <div>
     The first slot:
     <div>
@@ -123,7 +123,7 @@ A nice feature of slots is that they can have fallback content. If nothing gets 
       This is some fallback content for slot 2...
     </div>
   </div>
-</named-slot>
+</fallback-content>
 ```
 
 Ok, now it's time to get crazy. What if the fallback content generates more slots!? Those fallback slots can be targeted by the content. Here's an example based on [a post from the WebKit team](https://webkit.org/blog/4096/introducing-shadow-dom-api/):


### PR DESCRIPTION
I think is a cut-and-paste error from the example above for `named-slot`