### PR TITLE
Fix mixed-slot example.

### DIFF
--- a/current/en-us/5. templating/5. content-projection.md
+++ b/current/en-us/5. templating/5. content-projection.md
@@ -220,7 +220,7 @@ That was fun! But we can go deeper. What about slots, that target other slots wi
 
 ```HTML slot-to-mixed-slot.html
 <template>
-  <require from="./mixed-slot"></require>
+  <require from="./mixed-slot.html"></require>
 
   <div>
     <mixed-slot>
@@ -250,16 +250,14 @@ That was fun! But we can go deeper. What about slots, that target other slots wi
     </div>
     The second slot:
     <div>
-      <slot name="slot2">
-        The first fallback slot:
-        <div>
-          Default Content for Fallback Slot 1
-        </div>
-        The second fallback slot:
-        <div>
-          <div slot="slot2">This is user content for slot 2. (appearing in fallbackSlot2)</div>
-        </div>
-      </slot>
+      The first fallback slot:
+      <div>
+        Default Content for Fallback Slot 1
+      </div>
+      The second fallback slot:
+      <div>
+        <div slot="slot2">This is user content for slot 2. (appearing in fallbackSlot2)</div>
+      </div>
     </div>
   </div>
 </slot-to-mixed-slot>


### PR DESCRIPTION
Composed Visual Tree was wrong.

Add missing `.html` suffix to require for html-only custom element.