### PR TITLE
Contact Manager - Minor typo in filename "messages.ts"

### DIFF
--- a/current/en-us/2. tutorials/2. creating-a-contact-manager.md
+++ b/current/en-us/2. tutorials/2. creating-a-contact-manager.md
@@ -487,7 +487,7 @@ If you play around with the application for a bit, you'll notice a few "buggy" b
 
 The reason for these issues is that we have two separate components, our `contact-list` and our `contact-detail` which both have their own internal data structures and behaviors, but which do have an affect on each other. The router is controlling the contact detail screen, so it's the ultimate source of truth and the contact list should sync with it. To handle this, we're going to increase the amount of information in our system by introducing pub/sub. Let's create a couple of messages that our `contact-detail` component can publish and then let the `contact-list` subscribe to those and respond appropriately.
 
-```JavaScript message.js
+```JavaScript messages.js
 export class ContactUpdated {
   constructor(contact) {
     this.contact = contact;
@@ -500,7 +500,7 @@ export class ContactViewed {
   }
 }
 ```
-```TypeScript message.ts [variant]
+```TypeScript messages.ts [variant]
 export class ContactUpdated {
   constructor(public contact) { }
 }


### PR DESCRIPTION
Typo in filename under Adding Pub/Sub Messaging section.
Filename changed from "message.ts" to "messages.ts".