### PR TITLE
doc(dialog): useDefaultSettings should be useDefaults

### DIFF
--- a/current/en-us/7. plugins/5. dialog.md
+++ b/current/en-us/7. plugins/5. dialog.md
@@ -348,9 +348,9 @@ export function configure(aurelia) {
   aurelia.use
     .standardConfiguration()
     .developmentLogging()
-    .plugin(PLATFORM.moduleName('aurelia-dialog'), cfg => {
-        cfg.useDefaultSettings()
-            .useCSS('');
+    .plugin(PLATFORM.moduleName('aurelia-dialog'), config => {
+      config.useDefaults();
+      config.useCSS('');
     });
 
   aurelia.start().then(a => a.setRoot());


### PR DESCRIPTION
It was discovered by Wendee https://discourse.aurelia.io/t/aurelia-dialog-styling-the-dialog-documentation-not-working-for-me/2800/3