### PR TITLE
fix(containerless): inline notes for where it does not work

### DIFF
--- a/current/en-us/3. fundamentals/5. cheat-sheet.md
+++ b/current/en-us/3. fundamentals/5. cheat-sheet.md
@@ -1315,13 +1315,13 @@ export class SayHello {
 
 ### Custom Element Options
 
-* `@children(selector)` - Decorates a property to create an array on your class that has its items automatically synchronized based on a query selector against the element's immediate child content.
-* `@child(selector)` - Decorates a property to create a reference to a single immediate child content element.
+* `@children(selector)` - Decorates a property to create an array on your class that has its items automatically synchronized based on a query selector against the element's immediate child content. Does not work with `@containerless()`, see below.
+* `@child(selector)` - Decorates a property to create a reference to a single immediate child content element. Does not work with `@containerless()`, see below.
 * `@processContent(false|Function)` - Tells the compiler that the element's content requires special processing. If you provide `false` to the decorator, the compiler will not process the content of your custom element. It is expected that you will do custom processing yourself. But, you can also supply a custom function that lets you process the content during the view's compilation. That function can then return true/false to indicate whether or not the compiler should also process the content. The function takes the following form `function(compiler, resources, node, instruction):boolean`
 * `@useView(path)` - Specifies a different view to use.
 * `@noView()` - Indicates that this custom element does not have a view and that the author intends for the element to handle its own rendering internally.
 * `@inlineView(markup, dependencies?)` - Allows the developer to provide a string that will be compiled into the view.
-* `@useShadowDOM(options?: { mode: 'open' | 'closed' })` - Causes the view to be rendered in the ShadowDOM. When an element is rendered to ShadowDOM, a special `DOMBoundary` instance can optionally be injected into the constructor. This represents the shadow root.
+* `@useShadowDOM(options?: { mode: 'open' | 'closed' })` - Causes the view to be rendered in the ShadowDOM. When an element is rendered to ShadowDOM, a special `DOMBoundary` instance can optionally be injected into the constructor. This represents the shadow root.  Does not work with `@containerless()`, see below.
 * `@containerless()` - Causes the element's view to be rendered without the custom element container wrapping it. This cannot be used in conjunction with `@child`, `@children` or `@useShadowDOM` decorators. It also cannot be uses with surrogate behaviors. Use sparingly.
 
 ### SVG Elements

--- a/current/en-us/5. templating/4. custom-elements.md
+++ b/current/en-us/5. templating/4. custom-elements.md
@@ -374,13 +374,13 @@ Aurelia will project the element's content in to the template where the `<slot><
 
 There are lots of options that allow you to change how custom elements work. These are expressed by decorators added to the custom element's viewmodel or properties on the viewmodel.
 
-* `@child(selector)` - Decorates a property to create a reference to a single immediate child content element.
-* `@children(selector)` - Decorates a property to create an array of content elements. The array is automatically synchronized to the the element's immediate child content by a DOM query selector.
+* `@child(selector)` - Decorates a property to create a reference to a single immediate child content element. Does not work with `@containerless()`, see below.
+* `@children(selector)` - Decorates a property to create an array of content elements. The array is automatically synchronized to the the element's immediate child content by a DOM query selector. Does not work with `@containerless()`, see below.
 * `@processContent(false|Function)` - Tells the compiler that the element's content requires special processing. If you provide `false` to the decorator, the compiler will not process the content of your custom element. It is expected that you will do custom processing yourself. But, you can also supply a custom function that lets you process the content during the view's compilation. That function can then return true/false to indicate whether or not the compiler should also process the content. The function takes the following form `function(compiler, resources, node, instruction):boolean`
 * `@useView(path)` - Specifies a different view to use.
 * `@noView(dependencies?)` - Indicates that this custom element does not have a view and that the author intends for the element to handle its own rendering internally. This is extremely useful when "wrapping" legacy JavaScript widgets that programatically create their markup
 * `@inlineView(markup, dependencies?)` - Allows the developer to provide a string that will be compiled into the view.
-* `@useShadowDOM(options?: { mode: 'open' | 'closed' })` - Causes the view to be rendered in the ShadowDOM. When an element is rendered to ShadowDOM, a special `DOMBoundary` instance can optionally be injected into the constructor. This represents the shadow root.
+* `@useShadowDOM(options?: { mode: 'open' | 'closed' })` - Causes the view to be rendered in the ShadowDOM. When an element is rendered to ShadowDOM, a special `DOMBoundary` instance can optionally be injected into the constructor. This represents the shadow root. Does not work with `@containerless()`, see below.
 * `@containerless()` - Causes the element's view to be rendered without the custom element container wrapping it. This cannot be used in conjunction with `@child`, `@children` or `@useShadowDOM` decorators. It also cannot be used with surrogate behaviors. Use sparingly.
 * `@viewResources(...dependencies)` - Adds dependencies to the underlying View. Same as: `<require from="..."></require>`, but declared in the ViewModel. Arguments can either be strings with `moduleId`s, `Object`s with `src` and optionally `as` properties, or classes of the module to be included.
 


### PR DESCRIPTION
The specific documentation for  @children, @child, @useShadowDOM needs to
reference that @containerless doesn't work.

The note that it doesn't work is further down and very easy to miss.