### PR TITLE
Fix typo in validation plugin docs

### DIFF
--- a/current/en-us/7. plugins/3. validation.md
+++ b/current/en-us/7. plugins/3. validation.md
@@ -164,7 +164,7 @@ ValidationRules
   .on(patient);
 ```
 
-There is no requirement to apply the rules directly to an object or class, you can capture the ruleset in a variable or property using `.rule` instead:
+There is no requirement to apply the rules directly to an object or class, you can capture the ruleset in a variable or property using `.rules` instead:
 
 ```JavaScript Storing Rules in a Property
 const personRules = ValidationRules


### PR DESCRIPTION
the desctription refers to non-existent .role property