### PR TITLE
Internal references for event binding docs

### DIFF
--- a/current/en-us/4. binding/1. basics.md
+++ b/current/en-us/4. binding/1. basics.md
@@ -62,6 +62,10 @@ The cancel button uses the `trigger` command to attach an event listener to the 
 
 Aurelia will automatically call [`preventDefault()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) on events handled with `delegate` or `trigger` binding. Most of the time this is the behavior you want. To turn this off, return `true` from your event handler function.
 
+### Related documentation 
+- [Delegate vs Trigger](/docs/binding/delegate-vs-trigger)
+- [`self` binding behavior](/docs/binding/binding-behaviors#self)
+
 ## Function References
 
 While developing custom elements or custom attributes you may encounter a situation where you have a `@bindable` property that expects a reference to a function. Use the `call` binding command to declare and pass a function to the bindable property. The `call` command is superior to the `bind` command for this use-case because it will execute the function in the correct context, ensuring `this` is what you expect it to be.

--- a/current/en-us/4. binding/6. delegate-vs-trigger.md
+++ b/current/en-us/4. binding/6. delegate-vs-trigger.md
@@ -19,6 +19,8 @@ To find out if [event delegation](https://davidwalsh.name/event-delegate) can be
 
 Here's the [MDN page for blur](https://developer.mozilla.org/en-US/docs/Web/Events/blur). It has further info on event delegation techniques for the blur and focus events.
 
+When using `delegate` you might also want to use the [`self` binding behavior](/docs/binding/binding-behaviors#self).
+
 ### Exceptions to the general guidance above:
 
 #### Use `trigger` on buttons when the following conditions are met:

--- a/current/en-us/4. binding/9. binding-behaviors.md
+++ b/current/en-us/4. binding/9. binding-behaviors.md
@@ -199,6 +199,10 @@ onMouseDown(event) {
 }
 ```
 
+### Related documentation 
+- [The basics of binding DOM Events](/docs/binding/basics#dom-events)
+- [Delegate vs Trigger](/docs/binding/delegate-vs-trigger)
+
 ## Custom binding behaviors
 
 You can build custom binding behaviors just like you can build value converters. Instead of `toView` and `fromView` methods you'll create `bind(binding, scope, [...args])` and `unbind(binding, scope)` methods. In the bind method you'll add your behavior to the binding and in the unbind method you should cleanup whatever you did in the bind method to restore the binding instance to it's original state. The `binding` argument is the binding instance whose behavior you want to change. It's an implementation of the `Binding` interface. The `scope` argument is the binding's data-context. It provides access to the model the binding will be bound to via it's `bindingContext` and `overrideContext` properties.


### PR DESCRIPTION
Added some internal references between event binding documentation, following my question at https://discourse.aurelia.io/t/how-to-determine-if-events-from-customelements-should-bubble-or-not/3161/3