### PR TITLE
Add warning about v2.0 and IE11

### DIFF
--- a/current/en-us/7. plugins/5. dialog.md
+++ b/current/en-us/7. plugins/5. dialog.md
@@ -62,6 +62,9 @@ export function configure(aurelia) {
 > Warning
 > `PLATFORM.moduleName` should *not* be omitted if you are using *Webpack*.
 
+> Warning
+> When using *Webpack* and *IE11* you will need this *alias* `'aurelia-dialog': path.resolve(__dirname, 'node_modules/aurelia-dialog/dist/umd/dialog-aurelia.js')` added to the *Resolve* section of your `webpack.config.js`.
+
 ## Using The Plugin
 
 There are a few ways you can take advantage of the Aurelia dialog.


### PR DESCRIPTION
@3cp explains the issue here https://github.com/aurelia/dialog/issues/387 and here on [discourse](https://discourse.aurelia.io/t/ie11-dialog-promise-undefined/3240/16)

> v2 switched to native dynamic import() statement to simplify the code. This is indeed a breaking change for IE11.