### PR TITLE
doc(contact-manager-tutorial): fix layout issue in bootstrap v4

### DIFF
--- a/current/en-us/2. tutorials/2. creating-a-contact-manager.md
+++ b/current/en-us/2. tutorials/2. creating-a-contact-manager.md
@@ -68,6 +68,7 @@ import {PLATFORM} from 'aurelia-pal';
 export class App {
   configureRouter(config, router){
     config.title = 'Contacts';
+    config.options.pushState = true;
     config.map([
       { route: '',              moduleId: PLATFORM.moduleName('no-selection'),   title: 'Select' },
       { route: 'contacts/:id',  moduleId: PLATFORM.moduleName('contact-detail'), name:'contacts' }
@@ -86,6 +87,7 @@ export class App {
 
   configureRouter(config: RouterConfiguration, router: Router){
     config.title = 'Contacts';
+    config.options.pushState = true;
     config.map([
       { route: '',              moduleId: PLATFORM.moduleName('no-selection'),   title: 'Select' },
       { route: 'contacts/:id',  moduleId: PLATFORM.moduleName('contact-detail'), name:'contacts' }
@@ -114,17 +116,17 @@ Now that we've configured our application's navigation structure, we need to put
 <template>
   <require from="./styles.css"></require>
 
-  <nav class="navbar navbar-light bg-light fixed-top" role="navigation">
+  <nav class="navbar navbar-light bg-light border-bottom fixed-top" role="navigation">
     <a class="navbar-brand" href="#">
       <i class="fa fa-user"></i>
       <span>Contacts</span>
     </a>
   </nav>
 
-  <div class="container">
+  <div class="container-md">
     <div class="row">
-      <div class="col-md-4">Contact List Placeholder</div>
-      <router-view class="col-md-8"></router-view>
+      <div class="col-sm-5 col-md-4">Contact List Placeholder</div>
+      <router-view class="col-sm-7 col-md-8"></router-view>
     </div>
   </div>
 </template>
@@ -184,7 +186,7 @@ This will provide the basic functionality for our "no selection" screen. All we 
 ```HTML no-selection.html
 <template>
   <div class="no-selection text-center">
-    <h2>${message}</h2>
+    <h4>${message}</h4>
   </div>
 </template>
 ```
@@ -262,14 +264,12 @@ Finally, we have a `select` method for selecting a contact. We'll revisit this s
 ```HTML contact-list.html
 <template>
   <div class="contact-list">
-    <ul class="list-group">
-      <li repeat.for="contact of contacts" class="list-group-item ${contact.id === $parent.selectedId ? 'active' : ''}">
-        <a route-href="route: contacts; params.bind: {id:contact.id}" click.delegate="$parent.select(contact)">
-          <h4>${contact.firstName} ${contact.lastName}</h4>
-          <p>${contact.email}</p>
-        </a>
-      </li>
-    </ul>
+    <div class="list-group">
+      <a repeat.for="contact of contacts" class="list-group-item list-group-item-action ${contact.id === $parent.selectedId ? 'active' : ''}" route-href="route: contacts; params.bind: {id:contact.id}" click.delegate="$parent.select(contact)">
+        <strong>${contact.firstName} ${contact.lastName}</strong><br>
+        <small>${contact.email}</small>
+      </a>
+    </div>
   </div>
 </template>
 ```
@@ -285,17 +285,17 @@ Ok, now that we've got the contact list built, we need to use it. To do that, up
   <require from="./styles.css"></require>
   <require from="./contact-list"></require>
 
-  <nav class="navbar navbar-light bg-light fixed-top" role="navigation">
+  <nav class="navbar navbar-light bg-light border-bottom fixed-top" role="navigation">
     <a class="navbar-brand" href="#">
       <i class="fa fa-user"></i>
       <span>Contacts</span>
     </a>
   </nav>
 
-  <div class="container">
+  <div class="container-md">
     <div class="row">
-      <contact-list class="col-md-4"></contact-list>
-      <router-view class="col-md-8"></router-view>
+      <contact-list class="col-sm-5 col-md-4"></contact-list>
+      <router-view class="col-sm-7 col-md-8"></router-view>
     </div>
   </div>
 </template>
@@ -428,41 +428,41 @@ With that all in place, let's look at the view that will render this component. 
 <template>
   <div class="card">
     <div class="card-header text-white bg-primary">
-      <h3>Profile</h3>
+      Profile
     </div>
     <div class="card-body">
       <form role="form">
-        <div class="form-group">
-          <label class="col-sm-3 col-form-label">First Name</label>
-          <div class="col-sm-9">
+        <div class="form-group row">
+          <label class="col-md-3 col-form-label">First Name</label>
+          <div class="col-md-9">
             <input type="text" placeholder="first name" class="form-control" value.bind="contact.firstName">
           </div>
         </div>
 
-        <div class="form-group">
-          <label class="col-sm-3 col-form-label">Last Name</label>
-          <div class="col-sm-9">
+        <div class="form-group row">
+          <label class="col-md-3 col-form-label">Last Name</label>
+          <div class="col-md-9">
             <input type="text" placeholder="last name" class="form-control" value.bind="contact.lastName">
           </div>
         </div>
 
-        <div class="form-group">
-          <label class="col-sm-3 col-form-label">Email</label>
-          <div class="col-sm-9">
+        <div class="form-group row">
+          <label class="col-md-3 col-form-label">Email</label>
+          <div class="col-md-9">
             <input type="text" placeholder="email" class="form-control" value.bind="contact.email">
           </div>
         </div>
 
-        <div class="form-group">
-          <label class="col-sm-3 col-form-label">Phone Number</label>
-          <div class="col-sm-9">
+        <div class="form-group row">
+          <label class="col-md-3 col-form-label">Phone Number</label>
+          <div class="col-md-9">
             <input type="text" placeholder="phone number" class="form-control" value.bind="contact.phoneNumber">
           </div>
         </div>
       </form>
       <div>
         <button class="btn btn-success float-right" click.delegate="save()" disabled.bind="!canSave">Save</button>
-    </div>
+      </div>
     </div>
   </div>
 </template>
@@ -779,6 +779,7 @@ export class App {
 
   configureRouter(config, router) {
     config.title = 'Contacts';
+    config.options.pushState = true;
     config.map([
       { route: '',              moduleId: PLATFORM.moduleName('no-selection'),   title: 'Select'},
       { route: 'contacts/:id',  moduleId: PLATFORM.moduleName('contact-detail'), name:'contacts' }
@@ -801,6 +802,7 @@ export class App {
 
   configureRouter(config: RouterConfiguration, router: Router) {
     config.title = 'Contacts';
+    config.options.pushState = true;
     config.map([
       { route: '',              moduleId: PLATFORM.moduleName('no-selection'),   title: 'Select'},
       { route: 'contacts/:id',  moduleId: PLATFORM.moduleName('contact-detail'), name:'contacts' }
@@ -818,21 +820,19 @@ Ok, now that we've got an `api` property we can bind to, update your `app.html` 
   <require from="./styles.css"></require>
   <require from="./contact-list"></require>
 
-  <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
-    <div class="navbar-header">
-      <a class="navbar-brand" href="#">
-        <i class="fa fa-user"></i>
-        <span>Contacts</span>
-      </a>
-    </div>
+  <nav class="navbar navbar-light bg-light border-bottom fixed-top" role="navigation">
+    <a class="navbar-brand" href="#">
+      <i class="fa fa-user"></i>
+      <span>Contacts</span>
+    </a>
   </nav>
 
   <loading-indicator loading.bind="router.isNavigating || api.isRequesting"></loading-indicator>
 
-  <div class="container">
+  <div class="container-md">
     <div class="row">
-      <contact-list class="col-md-4"></contact-list>
-      <router-view class="col-md-8"></router-view>
+      <contact-list class="col-sm-5 col-md-4"></contact-list>
+      <router-view class="col-sm-7 col-md-8"></router-view>
     </div>
   </div>
 </template>

--- a/current/en-us/2. tutorials/2. creating-a-contact-manager.md
+++ b/current/en-us/2. tutorials/2. creating-a-contact-manager.md
@@ -69,6 +69,7 @@ export class App {
   configureRouter(config, router){
     config.title = 'Contacts';
     config.options.pushState = true;
+    config.options.root = '/';
     config.map([
       { route: '',              moduleId: PLATFORM.moduleName('no-selection'),   title: 'Select' },
       { route: 'contacts/:id',  moduleId: PLATFORM.moduleName('contact-detail'), name:'contacts' }
@@ -88,6 +89,7 @@ export class App {
   configureRouter(config: RouterConfiguration, router: Router){
     config.title = 'Contacts';
     config.options.pushState = true;
+    config.options.root = '/';
     config.map([
       { route: '',              moduleId: PLATFORM.moduleName('no-selection'),   title: 'Select' },
       { route: 'contacts/:id',  moduleId: PLATFORM.moduleName('contact-detail'), name:'contacts' }
@@ -108,7 +110,21 @@ In the case above, we are registering two routes. The first route is empty, indi
 > Info
 > Did you notice the calls to `PLATFORM.moduleName(....)`? This is a special API that is used in Aurelia Webpack projects to allow Webpack to identify strings that represent modules. This enables Webpack to include the referenced module in the built package.
 
-There are a couple more points of interest with this configuration. First, notice that we've set the `config.title` property. This sets a base "title" to be used in the document's title for the browser. We can also set a `title` on each route. When we do that, the router's title and the matched route's title will be joined together to form the final document title. The second thing to notice is that the second route has a `name` property. We'll be able to use this later to generate routes without needing to copy/paste the route pattern everywhere. Instead, we can just refer to the route by name.
+There are a couple more points of interest with this configuration.
+
+First, notice that we've set the `config.title` property. This sets a base "title" to be used in the document's title for the browser. We can also set a `title` on each route. When we do that, the router's title and the matched route's title will be joined together to form the final document title.
+
+Secondly, `config.options.pushState = true; config.options.root = '/';` is optional. They are to turn on [pushState based routing](/docs/routing/configuration#options). If you remove that two lines, Aurelia router will use default hash based routing which can work even on IE9.
+
+Examples of routing options:
+* pushState based: `http://localhost:8080/contacts/1`
+* hash based: `http://localhost:8080/#/contacts/1`
+
+> Info HTML5 History API (pushState)
+> HTML5 History API enables modifying a website's URL without a full page refresh. This is the essential browser feature that enabled JavaScript SPA (Single-Page-Application), it does NOT work in IE9 or any older IE.
+> https://developer.mozilla.org/en-US/docs/Web/API/History_API/Working_with_the_History_API
+
+The third thing to notice is that the second route has a `name` property. We'll be able to use this later to generate routes without needing to copy/paste the route pattern everywhere. Instead, we can just refer to the route by name.
 
 Now that we've configured our application's navigation structure, we need to put the visual structure in place. To do that, replace your `app.html` file with the following markup:
 
@@ -780,6 +796,7 @@ export class App {
   configureRouter(config, router) {
     config.title = 'Contacts';
     config.options.pushState = true;
+    config.options.root = '/';
     config.map([
       { route: '',              moduleId: PLATFORM.moduleName('no-selection'),   title: 'Select'},
       { route: 'contacts/:id',  moduleId: PLATFORM.moduleName('contact-detail'), name:'contacts' }
@@ -803,6 +820,7 @@ export class App {
   configureRouter(config: RouterConfiguration, router: Router) {
     config.title = 'Contacts';
     config.options.pushState = true;
+    config.options.root = '/';
     config.map([
       { route: '',              moduleId: PLATFORM.moduleName('no-selection'),   title: 'Select'},
       { route: 'contacts/:id',  moduleId: PLATFORM.moduleName('contact-detail'), name:'contacts' }


### PR DESCRIPTION
When this tutorial was upgraded from bootstrap v3 to v4, the layout is not quite right.
1. the left contact list is only clickable on the text, not the whole item.
2. the form layout is incorrect, leaving right side a blank gap.
3. some font size is too big, might due to bootstrap changes.
The updated code can be reviewed lively at https://gist.dumber.app/?gist=da1297fe5662ce31911cf5cb2bdce960
Also updated router config to use pushState.