### PR TITLE
Update broken link to component lifecycle

### DIFF
--- a/current/en-us/7. plugins/2. store.md
+++ b/current/en-us/7. plugins/2. store.md
@@ -384,7 +384,7 @@ export class App {
 ```
 
 > Info
-> The provided action names for setup and teardown don't necessarily have to be one of the official [lifecycle methods](http://aurelia.io/docs/fundamentals/components#the-component-lifecycle) but should be used as these get called automatically by Aurelia at the proper time.
+> The provided action names for setup and teardown don't necessarily have to be one of the official [lifecycle methods](https://aurelia.io/docs/fundamentals/creating-components#the-component-lifecycle) but should be used as these get called automatically by Aurelia at the proper time.
 
 Last but not least you can also handle changes from the state in multiple ways
 


### PR DESCRIPTION
From `http://aurelia.io/docs/fundamentals/components#the-component-lifecycle`
To `https://aurelia.io/docs/fundamentals/creating-components#the-component-lifecycle`